### PR TITLE
WIP: First step towards python bindings

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,22 @@
+import setuptools
+
+
+setuptools.setup(
+    name='deltachat',
+    version='0.1',
+    description='Python bindings for deltachat-core using CFFI',
+    author='Delta Chat contributors',
+    setup_requires=['cffi>=1.0.0'],
+    install_requires=['cffi>=1.0.0'],
+    packages=setuptools.find_packages('src'),
+    package_dir={'': 'src'},
+    cffi_modules=['src/deltachat/_build.py:ffibuilder'],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License (GPL)',
+        'Programming Language :: Python :: 3',
+        'Topic :: Communications :: Email',
+        'Topic :: Software Development :: Libraries',
+    ],
+)

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -1,23 +1,35 @@
-import subprocess
+import distutils.ccompiler
+import distutils.sysconfig
 import tempfile
 
 import cffi
 
 
-ffibuilder = cffi.FFI()
-ffibuilder.set_source(
-    'deltachat.capi',
-    """
-    #include <deltachat/mrmailbox.h>
-    """,
-    libraries=['deltachat'],
-)
-with tempfile.NamedTemporaryFile(mode='r') as fp:
-    proc = subprocess.run(['gcc', '-E', '-o', fp.name, '-DPY_CFFI=1',
-                           '../src/mrmailbox.h'])
-    proc.check_returncode()
-    ffibuilder.cdef(fp.read())
+def ffibuilder():
+    builder = cffi.FFI()
+    builder.set_source(
+        'deltachat.capi',
+        """
+            #include <deltachat/mrmailbox.h>
+        """,
+        libraries=['deltachat'],
+    )
+    builder.cdef("""
+        typedef int... time_t;
+    """)
+    cc = distutils.ccompiler.new_compiler(force=True)
+    distutils.sysconfig.customize_compiler(cc)
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.h') as src_fp:
+        src_fp.write('#include <deltachat/mrmailbox.h>')
+        src_fp.flush()
+        with tempfile.NamedTemporaryFile(mode='r') as dst_fp:
+            cc.preprocess(source=src_fp.name,
+                          output_file=dst_fp.name,
+                          macros=[('PY_CFFI', '1')])
+            builder.cdef(dst_fp.read())
+    return builder
 
 
 if __name__ == '__main__':
-    ffibuilder.compile(verbose=True)
+    builder = ffibuilder()
+    builder.compile(verbose=True)

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -1,0 +1,23 @@
+import subprocess
+import tempfile
+
+import cffi
+
+
+ffibuilder = cffi.FFI()
+ffibuilder.set_source(
+    'deltachat.capi',
+    """
+    #include <deltachat/mrmailbox.h>
+    """,
+    libraries=['deltachat'],
+)
+with tempfile.NamedTemporaryFile(mode='r') as fp:
+    proc = subprocess.run(['gcc', '-E', '-o', fp.name, '-DPY_CFFI=1',
+                           '../src/mrmailbox.h'])
+    proc.check_returncode()
+    ffibuilder.cdef(fp.read())
+
+
+if __name__ == '__main__':
+    ffibuilder.compile(verbose=True)

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -16,6 +16,7 @@ def ffibuilder():
     )
     builder.cdef("""
         typedef int... time_t;
+        void free(void *ptr);
     """)
     cc = distutils.ccompiler.new_compiler(force=True)
     distutils.sysconfig.customize_compiler(cc)

--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -150,18 +150,15 @@ extern "C" {
 #ifndef PY_CFFI
 #include <pthread.h>
 #include <libetpan/libetpan.h> /* defines uint16_t */
+#endif
+
 #include "mrarray.h"
-#endif
 #include "mrchatlist.h"
-#ifndef PY_CFFI
 #include "mrchat.h"
-#endif
 #include "mrmsg.h"
 #include "mrcontact.h"
-#ifndef PY_CFFI
 #include "mrlot.h"
 #include "mrevent.h"
-#endif
 
 
 /**

--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -147,15 +147,21 @@ extern "C" {
  */
 
 
+#ifndef PY_CFFI
 #include <pthread.h>
 #include <libetpan/libetpan.h> /* defines uint16_t */
 #include "mrarray.h"
+#endif
 #include "mrchatlist.h"
+#ifndef PY_CFFI
 #include "mrchat.h"
+#endif
 #include "mrmsg.h"
 #include "mrcontact.h"
+#ifndef PY_CFFI
 #include "mrlot.h"
 #include "mrevent.h"
+#endif
 
 
 /**

--- a/src/mrmsg.h
+++ b/src/mrmsg.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+#ifdef PY_CFFI
+typedef int... time_t;
+#endif
+
 
 typedef struct _mrmailbox mrmailbox_t;
 

--- a/src/mrmsg.h
+++ b/src/mrmsg.h
@@ -26,10 +26,6 @@
 extern "C" {
 #endif
 
-#ifdef PY_CFFI
-typedef int... time_t;
-#endif
-
 
 typedef struct _mrmailbox mrmailbox_t;
 


### PR DESCRIPTION
DO NOT MERGE

This is a very rough first stab at compiling CFFI Python bindings for deltachat-core.  It compiles and generates some bindings, but that's about it.

1. I've done this as a PR in this repo instead of a new one.  It makes header modifications easier and means I don't have to worry about copyrights.  It may even make sense to leave the raw bindings here but it can always be moved out later.

2. This runs the header files through the preprocessor (`gcc -E`) using the `PY_CFFI` symbol to end up with something which is parsable by cffi.  I think this will stay but the implementation cleaned up somewhat and the number of ifdefs reduced.

3. I've effectively made the structs opaque/private for cffi.  I did this as otherwise I had to worry about defining opaque structs for pthread_t and related friends.  Since you consider them private anyway maybe it's better to do that right away and properly instead of my cffi-specific hack here (I guess with `typedef _mrmailbox mrmailbox_t;` + mrmailbox-private.h etc?)

4. I've chopped up the included headers with ifdef.  That's just temporarily, once we have opaque structs and all public.h files are parsable by cffi only the external includes need to be ifdef'ed out.

5. I have no idea what `clist` is supposed to be and where it comes from.  I've defined it as an opaque struct and it seems to work.  I'd know better what to do with it if I knew more about it.

6. Mostly as an aside, some header files seem to have incomplete includes, e.g. `mrmsg.h` uses `time_t` but doesn't include `time.h`.