### PR TITLE
Make libbz2 a proper dependency

### DIFF
--- a/libs/netpgp/meson.build
+++ b/libs/netpgp/meson.build
@@ -1,9 +1,14 @@
 project('netpgp', 'c')
 
+# pkg-config dependencies
 zlib = dependency('zlib')
-bzip2 = declare_dependency(link_args: '-lbz2')
 openssl = dependency('openssl')
 pthreads = dependency('threads')
+
+# Dependencies without pkg-config, just try linking against them
+compiler = meson.get_compiler('c')
+bzip2 = compiler.find_library('bz2')
+
 
 src = [
   'src/compress.c',


### PR DESCRIPTION
This makes sure that at meson/configure time the build will fail
with an error saying the library can't be found.  This is much
better then a mysterious link error right at the end of the
compilation.