### PR TITLE
patch makes meson create pkg-config file so apps can make use of it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,3 +40,18 @@ subdir('src')
 
 # Build the binaries.
 subdir('cmdline')
+
+version = run_command('git', 'describe', '--tags')
+if version.returncode() != 0
+  version = 'unknown-error'
+else
+  version = version.stdout().strip()
+endif
+
+pkg = import('pkgconfig')
+pkg.generate(libraries : lib,
+             version : version,
+             subdirs : ['deltachat'],
+             name : 'libdeltachat',
+             filebase : 'deltachat',
+             description : ' Create your own, email-compatible messenger.')


### PR DESCRIPTION
I am working on a plugin using deltachat-core. this patch makes meson create a pkg-config file so my library can make use of it easily.