### PR TITLE
improve autoconfig

### DIFF
--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -302,7 +302,7 @@ void            mrmailbox_heartbeat         (mrmailbox_t*);
 
 
 /* out-of-band verification */
-#define         MR_QR_FPR_ASK_OOB           200 /* id=contact, test2=return_tag */
+#define         MR_QR_FPR_ASK_OOB           200 /* id=contact, text2=random secret */
 #define         MR_QR_FPR_OK                210 /* id=contact */
 #define         MR_QR_FPR_MISMATCH          220 /* id=contact */
 #define         MR_QR_FPR_WITHOUT_ADDR      230 /* test1=formatted fingerprint */

--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -302,7 +302,7 @@ void            mrmailbox_heartbeat         (mrmailbox_t*);
 
 
 /* out-of-band verification */
-#define         MR_QR_FPR_ASK_OOB           200 /* id=contact, text2=random secret */
+#define         MR_QR_FPR_ASK_OOB           200 /* id=contact, text1=fingerprint, text2=random secret */
 #define         MR_QR_FPR_OK                210 /* id=contact */
 #define         MR_QR_FPR_MISMATCH          220 /* id=contact */
 #define         MR_QR_FPR_WITHOUT_ADDR      230 /* test1=formatted fingerprint */

--- a/src/mrmailbox_configure.c
+++ b/src/mrmailbox_configure.c
@@ -500,7 +500,16 @@ int mrmailbox_configure_and_connect(mrmailbox_t* mailbox)
 				char* url = mr_mprintf("%s://autoconfig.%s/mail/config-v1.1.xml?emailaddress=%s", i==0?"https":"http", param_domain, param_addr_urlencoded); /* Thunderbird may or may not use SSL */
 				param_autoconfig = moz_autoconfigure(mailbox, url, param);
 				free(url);
-				PROGRESS(300+i*50)
+				PROGRESS(300+i*20)
+			}
+		}
+
+		for( i = 0; i <= 1; i++ ) {
+			if( param_autoconfig==NULL ) {
+				char* url = mr_mprintf("%s://%s/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=%s", i==0?"https":"http", param_domain, param_addr_urlencoded); // the doc does not mention `emailaddress=`, however, Thunderbird adds it, see https://releases.mozilla.org/pub/thunderbird/ ,  which makes some sense
+				param_autoconfig = moz_autoconfigure(mailbox, url, param);
+				free(url);
+				PROGRESS(340+i*30)
 			}
 		}
 

--- a/src/mrmimefactory.c
+++ b/src/mrmimefactory.c
@@ -563,7 +563,7 @@ int mrmimefactory_render(mrmimefactory_t* factory, int encrypt_to_self)
 
 				char* random_secret = mrparam_get(msg->m_param, MRP_SYSTEM_CMD_PARAM2, NULL);
 				if( random_secret ) {
-					mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Secure-Join-Random.Secret"), random_secret/*mailimf takes ownership of string*/));
+					mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Secure-Join-Random-Secret"), random_secret/*mailimf takes ownership of string*/));
 				}
 
 				char* fingerprint = mrparam_get(msg->m_param, MRP_SYSTEM_CMD_PARAM3, NULL);

--- a/src/mrmimefactory.c
+++ b/src/mrmimefactory.c
@@ -557,8 +557,20 @@ int mrmimefactory_render(mrmimefactory_t* factory, int encrypt_to_self)
 
 		if( system_command == MR_SYSTEM_OOB_VERIFY_MESSAGE ) {
 			char* step = mrparam_get(msg->m_param, MRP_SYSTEM_CMD_PARAM, NULL);
-			mrmailbox_log_info(msg->m_mailbox, 0, "sending secure-join message '%s' >>>>>>>>>>>>>>>>>>>>>>>>>", step);
-			mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Secure-Join"), step/*mailimf takes ownership of string*/));
+			if( step ) {
+				mrmailbox_log_info(msg->m_mailbox, 0, "sending secure-join message '%s' >>>>>>>>>>>>>>>>>>>>>>>>>", step);
+				mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Secure-Join"), step/*mailimf takes ownership of string*/));
+
+				char* random_secret = mrparam_get(msg->m_param, MRP_SYSTEM_CMD_PARAM2, NULL);
+				if( random_secret ) {
+					mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Secure-Join-Random.Secret"), random_secret/*mailimf takes ownership of string*/));
+				}
+
+				char* fingerprint = mrparam_get(msg->m_param, MRP_SYSTEM_CMD_PARAM3, NULL);
+				if( fingerprint ) {
+					mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Secure-Join-Fingerprint"), fingerprint/*mailimf takes ownership of string*/));
+				}
+			}
 		}
 
 		if( grpimage )

--- a/src/mrparam.h
+++ b/src/mrparam.h
@@ -56,6 +56,8 @@ typedef struct mrparam_t
 #define MRP_FORWARDED         'a'  /* for msgs */
 #define MRP_SYSTEM_CMD        'S'  /* for msgs */
 #define MRP_SYSTEM_CMD_PARAM  'E'  /* for msgs */
+#define MRP_SYSTEM_CMD_PARAM2 'F'  /* for msgs */
+#define MRP_SYSTEM_CMD_PARAM3 'G'  /* for msgs */
 
 #define MRP_SERVER_FOLDER     'Z'  /* for jobs */
 #define MRP_SERVER_UID        'z'  /* for jobs */


### PR DESCRIPTION
search for autoconfig also in example.com/.well-known/autoconfig/mail dir

refers to  https://github.com/deltachat/deltachat-core/commit/5cee73a750091d3a20b645fd37ca7863573f3e3e#commitcomment-28308841

regarding the `emailaddress=` parameter:
the [doc](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) does not mention it, however, Thunderbird uses it, at least in the [source code](https://releases.mozilla.org/pub/thunderbird/) 45.5.1. as it makes some sense, i do not think, this has changed: the .well-known dir is for users who cannot add a subdomain - why not give them the same options (to return eg. customized login names) as for the subdomain solution.

looking at the thunderbird source code, i am also wondering, why they do not look at the https domains, however, i have not dived deeply in the source code, maybe their http-request object just uses both variants or they rely on a redirection. i think, for delta, it makes some sense to use both variants.