### PR TITLE
Write memoryhole

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,7 @@ lib_hdr = [
   'mrcontact.h',
   'mrdehtml.h',
   'mrevent.h',
+  'mrerror.h',
   'mrhash.h',
   'mrimap.h',
   'mrjob.h',

--- a/src/mrerror.h
+++ b/src/mrerror.h
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *
+ *                              Delta Chat Core
+ *                   Contact: r10s@b44t.com, http://b44t.com
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see http://www.gnu.org/licenses/ .
+ *
+ ******************************************************************************/
+
+
+#ifndef __MRERROR_H__
+#define __MRERROR_H__
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @file
+ *
+ * The following constants are used as error codes used by the event 
+ * MR_EVENT_ERROR (see mrevent.h) and reported to the callback given to
+ * mrmailbox_new().
+ */
+
+
+/**
+ * Details about the error can be found in data2. Reported by MR_EVENT_ERROR.
+ */
+#define MR_ERR_SEE_STRING                 0
+
+
+/**
+ * Details about the error can be found in data2. Reported by MR_EVENT_ERROR.
+ */
+#define MR_ERR_SELF_NOT_IN_GROUP          1
+
+
+/**
+ * Details about the error can be found in data2. Reported by MR_EVENT_ERROR.
+ */
+#define MR_ERR_NONETWORK                  2
+
+
+#ifdef __cplusplus
+} /* /extern "C" */
+#endif
+#endif /* __MRERROR_H__ */
+

--- a/src/mrevent.h
+++ b/src/mrevent.h
@@ -36,13 +36,14 @@ extern "C" {
 
 
 /**
- * The user may write an informational string to the log.
+ * The library-user may write an informational string to the log.
  * Passed to the callback given to mrmailbox_new().
- * This event should not be reported using a popup or something like that.
+ *
+ * This event should not be reported to the end-user using a popup or something like that.
  *
  * @param data1 0
  *
- * @param data2 Info string
+ * @param data2 Info string in english language.
  *
  * @return 0
  */
@@ -50,13 +51,14 @@ extern "C" {
 
 
 /**
- * The user should write a warning string to the log.
+ * The library-user should write a warning string to the log.
  * Passed to the callback given to mrmailbox_new().
- * This event should not be reported using a popup or something like that.
+ *
+ * This event should not be reported to the end-user using a popup or something like that.
  *
  * @param data1 0
  *
- * @param data2 Warning string
+ * @param data2 Warning string in english language.
  *
  * @return 0
  */
@@ -64,16 +66,29 @@ extern "C" {
 
 
 /**
- * The user should show an error.
- * The error must be reported to the user by a non-disturbing bubble or so.
+ * The library-user should report an error to the end-user.
+ * Passed to the callback given to mrmailbox_new().
  *
- * @param data1 0
+ * As most things are asynchrounous, things may go wrong at any time and the user
+ * should not be disturbed by a dialog or so.  Instead, use a bubble or so.
  *
- * @param data2 Error string
+ * However, for ongoing processes (eg. mrmailbox_configure_and_connect())
+ * or for functions that are expected to fail (eg. mrmailbox_continue_key_transfer())
+ * it might be better to delay showing these events until the function has really
+ * failed (returned false). It should be sufficient to report only the _last_ error
+ * in a messasge box then.
+ *
+ * @param data1 Error code, see mrerror.h for a list of constants.
+ *
+ * @param data2 Error string, always set, never NULL. Frequent error strings are
+ *     localized using MR_EVENT_GET_STRING, however, most error strings will be
+ *     in english language.
+ *
  *
  * @return 0
  */
 #define MR_EVENT_ERROR                    400
+
 
 
 /**

--- a/src/mrmailbox-private.h
+++ b/src/mrmailbox-private.h
@@ -77,6 +77,15 @@ struct _mrmailbox
 
 };
 
+
+/* logging and error handling */
+void            mrmailbox_log_error         (mrmailbox_t*, int code, const char* msg, ...);
+void            mrmailbox_log_error_if      (int* condition, mrmailbox_t*, int code, const char* msg, ...);
+void            mrmailbox_log_warning       (mrmailbox_t*, int code, const char* msg, ...);
+void            mrmailbox_log_info          (mrmailbox_t*, int code, const char* msg, ...);
+
+
+/* misc.*/
 void            mrmailbox_receive_imf                             (mrmailbox_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 uint32_t        mrmailbox_send_msg_object                         (mrmailbox_t*, uint32_t chat_id, mrmsg_t*);
 void            mrmailbox_connect_to_imap                         (mrmailbox_t*, mrjob_t*);

--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -157,6 +157,7 @@ extern "C" {
 #include "mrcontact.h"
 #include "mrlot.h"
 #include "mrevent.h"
+#include "mrerror.h"
 
 
 /**
@@ -312,18 +313,6 @@ void            mrmailbox_heartbeat         (mrmailbox_t*);
 mrlot_t*        mrmailbox_check_qr          (mrmailbox_t*, const char* qr);
 char*           mrmailbox_oob_get_qr        (mrmailbox_t*);
 int             mrmailbox_oob_join          (mrmailbox_t*, const char* qr);
-
-
-/* logging */
-void            mrmailbox_log_error         (mrmailbox_t*, int code, const char* msg, ...);
-void            mrmailbox_log_error_if      (int* condition, mrmailbox_t*, int code, const char* msg, ...);
-void            mrmailbox_log_warning       (mrmailbox_t*, int code, const char* msg, ...);
-void            mrmailbox_log_info          (mrmailbox_t*, int code, const char* msg, ...);
-
-
-/* error codes */
-#define         MR_ERR_SELF_NOT_IN_GROUP    1
-#define         MR_ERR_NONETWORK            2
 
 
 /* deprecated functions */

--- a/src/mrmailbox_e2ee.c
+++ b/src/mrmailbox_e2ee.c
@@ -459,7 +459,7 @@ void mrmailbox_e2ee_encrypt(mrmailbox_t* mailbox, const clist* recipients_addr,
 		if( plain->str == NULL || plain->len<=0 ) {
 			goto cleanup;
 		}
-		char* t1=mr_null_terminate(plain->str,plain->len);printf("PLAIN:\n%s\n",t1);free(t1); // DEBUG OUTPUT
+		//char* t1=mr_null_terminate(plain->str,plain->len);printf("PLAIN:\n%s\n",t1);free(t1); // DEBUG OUTPUT
 
 		if( !mrpgp_pk_encrypt(mailbox, plain->str, plain->len, keyring, sign_key, 1/*use_armor*/, (void**)&ctext, &ctext_bytes) ) {
 			goto cleanup;

--- a/src/mrmailbox_e2ee.c
+++ b/src/mrmailbox_e2ee.c
@@ -390,6 +390,10 @@ void mrmailbox_e2ee_encrypt(mrmailbox_t* mailbox, const clist* recipients_addr,
 	mrsqlite3_unlock(mailbox->m_sql);
 	locked = 0;
 
+	if( (imffields_unprotected=mailmime_find_mailimf_fields(in_out_message))==NULL ) {
+		goto cleanup;
+	}
+
 	/* encrypt message, if possible */
 	if( do_encrypt )
 	{
@@ -413,12 +417,49 @@ void mrmailbox_e2ee_encrypt(mrmailbox_t* mailbox, const clist* recipients_addr,
 			}
 		}
 
+		/* memoryhole headers */
+		clistiter* cur = clist_begin(imffields_unprotected->fld_list);
+		while( cur!=NULL ) {
+			int move_to_encrypted = 0;
+
+			struct mailimf_field* field = (struct mailimf_field*)clist_content(cur);
+			if( field ) {
+				if( field->fld_type == MAILIMF_FIELD_SUBJECT ) {
+					move_to_encrypted = 1;
+				}
+				else if( field->fld_type == MAILIMF_FIELD_OPTIONAL_FIELD ) {
+					struct mailimf_optional_field* opt_field = field->fld_data.fld_optional_field;
+					if( opt_field
+					 && strncmp(opt_field->fld_name, "Chat-", 5)==0 && strcmp(opt_field->fld_name, "Chat-Version")!=0/*Chat-Version may be used for filtering, however, this is subject to cha*/ ) {
+						move_to_encrypted = 1;
+					}
+				}
+			}
+
+			if( move_to_encrypted ) {
+				mailimf_fields_add(imffields_encrypted, field);
+				cur = clist_delete(imffields_unprotected->fld_list, cur);
+			}
+			else {
+				cur = clist_next(cur);
+			}
+		}
+
+		char* subject_str = mrstock_str(MR_STR_ENCRYPTEDMSG);
+		struct mailimf_subject* subject = mailimf_subject_new(mr_encode_header_string(subject_str));
+		mailimf_fields_add(imffields_unprotected, mailimf_field_new(MAILIMF_FIELD_SUBJECT, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, subject, NULL, NULL, NULL));
+		free(subject_str);
+
+		// TODO: this dies
+		struct mailmime_content* content_to_encrypt = part_to_encrypt->mm_content_type;
+		clist_append(content_to_encrypt->ct_parameters, mailmime_param_new_with_data("protected-headers", "v1"));
+
 		/* convert part to encrypt to plain text */
 		mailmime_write_mem(plain, &col, message_to_encrypt);
 		if( plain->str == NULL || plain->len<=0 ) {
 			goto cleanup;
 		}
-		//char* t1=mr_null_terminate(plain->str,plain->len);printf("PLAIN:\n%s\n",t1);free(t1); // DEBUG OUTPUT
+		char* t1=mr_null_terminate(plain->str,plain->len);printf("PLAIN:\n%s\n",t1);free(t1); // DEBUG OUTPUT
 
 		if( !mrpgp_pk_encrypt(mailbox, plain->str, plain->len, keyring, sign_key, 1/*use_armor*/, (void**)&ctext, &ctext_bytes) ) {
 			goto cleanup;
@@ -446,13 +487,6 @@ void mrmailbox_e2ee_encrypt(mrmailbox_t* mailbox, const clist* recipients_addr,
 		//MMAPString* t3=mmap_string_new("");mailmime_write_mem(t3,&col,in_out_message);char* t4=mr_null_terminate(t3->str,t3->len); printf("ENCRYPTED+MIME_ENCODED:\n%s\n",t4);free(t4);mmap_string_free(t3); // DEBUG OUTPUT
 
 		helper->m_encryption_successfull = 1;
-	}
-
-	/* add Autocrypt:-header to allow the recipient to send us encrypted messages back
-	(the Autocrypt:-header in the IMAP copy is needed to detect the presence of the first Autocrypt:-client if the user tries to enable multiple device
-	(we show a warning then to avoid the generation of a second keypair and to allow the user to import the first key)) */
-	if( (imffields_unprotected=mailmime_find_mailimf_fields(in_out_message))==NULL ) {
-		goto cleanup;
 	}
 
 	char* p = mraheader_render(autocryptheader);

--- a/src/mrmailbox_oob.c
+++ b/src/mrmailbox_oob.c
@@ -30,9 +30,6 @@
 
 /* - TODO: the out-of-band verification messages should not appear as normal system messages,
      only the result should be shown. however, for debugging it is nice to have them visible.
-
-   - TODO: make sure, all Secure-Join:-headers go to the encrypted payload (except for the first, unencrypted message)
-
 */
 
 

--- a/src/mrmimefactory.c
+++ b/src/mrmimefactory.c
@@ -714,6 +714,16 @@ int mrmimefactory_render(mrmimefactory_t* factory, int encrypt_to_self)
 	/* Encrypt the message
 	 *************************************************************************/
 
+	if( factory->m_loaded==MR_MF_MDN_LOADED ) {
+		char* e = mrstock_str(MR_STR_READRCPT); subject_str = mr_mprintf(MR_CHAT_PREFIX " %s", e); free(e);
+	}
+	else {
+		subject_str = get_subject(factory->m_chat, factory->m_msg, afwd_email);
+	}
+
+	struct mailimf_subject* subject = mailimf_subject_new(mr_encode_header_string(subject_str));
+	mailimf_fields_add(imf_fields, mailimf_field_new(MAILIMF_FIELD_SUBJECT, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, subject, NULL, NULL, NULL));
+
 	if( !force_unencrypted ) {
 		if( encrypt_to_self==0 || e2ee_guaranteed ) {
 			/* we're here (1) _always_ on SMTP and (2) on IMAP _only_ if SMTP was encrypted before - otherwise we can save some bytes in not-sending the Autocrypt-header to ourself */
@@ -721,21 +731,9 @@ int mrmimefactory_render(mrmimefactory_t* factory, int encrypt_to_self)
 		}
 	}
 
-	/* add a subject line */
 	if( e2ee_helper.m_encryption_successfull ) {
-		char* e = mrstock_str(MR_STR_ENCRYPTEDMSG); subject_str = mr_mprintf(MR_CHAT_PREFIX " %s", e); free(e);
 		factory->m_out_encrypted = 1;
 	}
-	else {
-		if( factory->m_loaded==MR_MF_MDN_LOADED ) {
-			char* e = mrstock_str(MR_STR_READRCPT); subject_str = mr_mprintf(MR_CHAT_PREFIX " %s", e); free(e);
-		}
-		else {
-			subject_str = get_subject(factory->m_chat, factory->m_msg, afwd_email);
-		}
-	}
-	struct mailimf_subject* subject = mailimf_subject_new(mr_encode_header_string(subject_str));
-	mailimf_fields_add(imf_fields, mailimf_field_new(MAILIMF_FIELD_SUBJECT, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, subject, NULL, NULL, NULL));
 
 	/* create the full mail and return */
 	factory->m_out = mmap_string_new("");


### PR DESCRIPTION
moving sensible headers from the unencrypted part to the header of the encrypted payload.

headers moved are: `Subject`, the `Secure-Join`-headers (used for the newQR code verification) and all `Chat-` headers (but  `Chat-Version` as there is a rough idea that this can be used for filtering).

moreover, the `Autocrypt-Gossip` headers are also moved here.

nb: older Delta Chat versions can read these headers already since [v0.11.4](https://github.com/deltachat/deltachat-android/blob/master/CHANGELOG.md#v0114)

information: https://github.com/autocrypt/memoryhole/ (this doc really needs some maintenance)

maybe in the future further headers can be moved to the encrypted part, however, this needs some discussions wirh the memoryhole people; however, at least, the code is now there :)