### PR TITLE
support hidden messages

### DIFF
--- a/src/mrchatlist.c
+++ b/src/mrchatlist.c
@@ -319,7 +319,7 @@ int mrchatlist_load_from_db__(mrchatlist_t* ths, int listflags, const char* quer
 
 	/* select example with left join and minimum: http://stackoverflow.com/questions/7588142/mysql-left-join-min */
 	#define QUR1 "SELECT c.id, m.id FROM chats c " \
-	                " LEFT JOIN msgs m ON (c.id=m.chat_id AND m.timestamp=(SELECT MAX(timestamp) FROM msgs WHERE chat_id=c.id)) " \
+	                " LEFT JOIN msgs m ON (c.id=m.chat_id AND m.timestamp=(SELECT MAX(timestamp) FROM msgs WHERE chat_id=c.id AND hidden=0)) " \
 	                " WHERE c.id>" MR_STRINGIFY(MR_CHAT_ID_LAST_SPECIAL) " AND c.blocked=0"
 	#define QUR2    " GROUP BY c.id " /* GROUP BY is needed as there may be several messages with the same timestamp */ \
 	                " ORDER BY MAX(c.draft_timestamp, IFNULL(m.timestamp,0)) DESC,m.id DESC;" /* the list starts with the newest chats */

--- a/src/mrcontact.h
+++ b/src/mrcontact.h
@@ -37,6 +37,7 @@ extern "C" {
 typedef struct _mrcontact mrcontact_t;
 
 #define         MR_CONTACT_ID_SELF         1
+#define         MR_CONTACT_ID_SYSTEM       2
 #define         MR_CONTACT_ID_LAST_SPECIAL 9
 
 

--- a/src/mrmailbox_oob.c
+++ b/src/mrmailbox_oob.c
@@ -426,6 +426,7 @@ static void send_handshake_msg(mrmailbox_t* mailbox, uint32_t chat_id, const cha
 
 	msg->m_type = MR_MSG_TEXT;
 	msg->m_text = mr_mprintf("Secure-Join: %s", step);
+	msg->m_hidden = 1;
 	mrparam_set_int(msg->m_param, MRP_SYSTEM_CMD,       MR_SYSTEM_OOB_VERIFY_MESSAGE);
 	mrparam_set    (msg->m_param, MRP_SYSTEM_CMD_PARAM, step);
 

--- a/src/mrmsg-private.h
+++ b/src/mrmsg-private.h
@@ -75,6 +75,8 @@ struct _mrmsg
 
 	int             m_state;                  /**< Message state. It is recommended to use mrmsg_get_state() to access this field. */
 
+	int             m_hidden;                 /**< Used eg. for handshaking messages. */
+
 	time_t          m_timestamp;              /**< Unix time for sorting. 0 if unset. */
 	time_t          m_timestamp_sent;         /**< Unix time the message was sent. 0 if unset. */
 	time_t          m_timestamp_rcvd;         /**< Unix time the message was recveived. 0 if unset. */

--- a/src/mrmsg.c
+++ b/src/mrmsg.c
@@ -106,6 +106,8 @@ void mrmsg_empty(mrmsg_t* msg)
 	mrparam_set_packed(msg->m_param, NULL);
 
 	msg->m_mailbox = NULL;
+
+	msg->m_hidden = 0;
 }
 
 
@@ -853,7 +855,7 @@ cleanup:
 
 #define MR_MSG_FIELDS " m.id,rfc724_mid,m.server_folder,m.server_uid,m.chat_id, " \
                       " m.from_id,m.to_id,m.timestamp,m.timestamp_sent,m.timestamp_rcvd, m.type,m.state,m.msgrmsg,m.txt, " \
-                      " m.param,m.starred,c.blocked "
+                      " m.param,m.starred,m.hidden,c.blocked "
 
 
 static int mrmsg_set_from_stmt__(mrmsg_t* ths, sqlite3_stmt* row, int row_offset) /* field order must be MR_MSG_FIELDS */
@@ -879,6 +881,7 @@ static int mrmsg_set_from_stmt__(mrmsg_t* ths, sqlite3_stmt* row, int row_offset
 
 	mrparam_set_packed(  ths->m_param, (char*)sqlite3_column_text (row, row_offset++));
 	ths->m_starred      =                     sqlite3_column_int  (row, row_offset++);
+	ths->m_hidden       =                     sqlite3_column_int  (row, row_offset++);
 	ths->m_chat_blocked =                     sqlite3_column_int  (row, row_offset++);
 
 	if( ths->m_chat_blocked == 2 ) {

--- a/src/mrsqlite3.c
+++ b/src/mrsqlite3.c
@@ -371,6 +371,16 @@ int mrsqlite3_open__(mrsqlite3_t* ths, const char* dbfile, int flags)
 				mrsqlite3_set_config_int__(ths, "dbversion", NEW_DB_VERSION);
 			}
 		#undef NEW_DB_VERSION
+
+		#define NEW_DB_VERSION 28
+			if( dbversion < NEW_DB_VERSION )
+			{
+				mrsqlite3_execute__(ths, "ALTER TABLE msgs ADD COLUMN hidden INTEGER DEFAULT 0;");
+
+				dbversion = NEW_DB_VERSION;
+				mrsqlite3_set_config_int__(ths, "dbversion", NEW_DB_VERSION);
+			}
+		#undef NEW_DB_VERSION
 	}
 
 	mrmailbox_log_info(ths->m_mailbox, 0, "Opened \"%s\" successfully.", dbfile);


### PR DESCRIPTION
hidden messages are needed as the handshake messages for the secure-join messages sent after a QR scan should not appear in the normal chats. Instead, a resulting "system message" as "contact verified" or so should appear.

btw: an alternative to hiding messages would be to allow sending normal MIME-messages without the database background, however, this seems even more complicated as the current approach offers contact_ids, easy deletion and so on. and hiding messages may get handy for other things, too.