### PR TITLE
allow curl to perform "insecure" SSL connections

### DIFF
--- a/cmdline/main.c
+++ b/cmdline/main.c
@@ -81,7 +81,7 @@ static uintptr_t receive_event(mrmailbox_t* mailbox, int event, uintptr_t data1,
 			{
 				char* ret = NULL;
 				char* tempFile = mr_get_fine_pathNfilename(mailbox->m_blobdir, "curl.result");
-				char* cmd = mr_mprintf("curl --silent --location --fail %s > %s", (char*)data1, tempFile); /* --location = follow redirects */
+				char* cmd = mr_mprintf("curl --silent --location --fail --insecure %s > %s", (char*)data1, tempFile); /* --location = follow redirects */
 				int error = system(cmd);
 				if( error == 0 ) { /* -1=system() error, !0=curl errors forced by -f, 0=curl success */
 					size_t bytes = 0;


### PR DESCRIPTION
allow curl to perform "insecure" SSL connections using flag '--insecure'
Without this flag, curl exited with error 51: The peer's SSL certificate or SSH MD5 fingerprint was not OK.
autoconfig attempts to https URLs did not succeed.