### PR TITLE
meson: at least version 0.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ these to work.
 
 - [bzip2](http://bzip.org)
 
-To build you need to have [meson](http://mesonbuild.com) and
+To build you need to have [meson](http://mesonbuild.com) (at least version 0.36.0) and
 [ninja](https://ninja-build.org) installed as well.
 
 On Linux (e.g. Debian Stretch) you can install all these using: 


### PR DESCRIPTION
I tried to follow the instruction, however Ubuntu 16.04 has a version of meson that seems to be too old.

Googling for the error I found https://github.com/haecker-felix/gradio/issues/183 which pointed me to the solution.
Installation worked with 0.45.1.

Not sure whether 0.36.0 is sufficient.