### PR TITLE
Feature: Detect IMAP separator for INBOX subfolder

### DIFF
--- a/src/mrchat-private.h
+++ b/src/mrchat-private.h
@@ -62,7 +62,6 @@ int             mrchat_are_all_members_verified__ (mrchat_t*);
 
 #define         MR_CHAT_PREFIX              "Chat:"      /* you MUST NOT modify this or the following strings */
 #define         MR_CHATS_FOLDER             "Chats"      /* if we want to support Gma'l-labels - "Chats" is a reserved word for Gma'l */
-#define         MR_CHATS_FOLDER_FALLBACK    "INBOX.Chats"/* This is used if the toplevel folder can't be created (e.g DomainFactory) */
 
 
 #ifdef __cplusplus

--- a/src/mrimap.c
+++ b/src/mrimap.c
@@ -233,10 +233,16 @@ static clist* list_folders__(mrimap_t* ths)
 		mrmailbox_log_warning(ths->m_mailbox, 0, "Cannot get folder list.");
 		goto cleanup;
 	}
-
+	//default IMAP delimiter if none is returned by the list command
+	ths->m_imap_delimiter = '.';
 	for( iter1 = clist_begin(imap_list); iter1 != NULL ; iter1 = clist_next(iter1) )
 	{
 		struct mailimap_mailbox_list* imap_folder = (struct mailimap_mailbox_list*)clist_content(iter1);
+		if (imap_folder->mb_delimiter) {
+			/* Set IMAP delimiter */
+			ths->m_imap_delimiter = imap_folder->mb_delimiter;
+		}
+
 		mrimapfolder_t* ret_folder = calloc(1, sizeof(mrimapfolder_t));
 
 		if( strcasecmp(imap_folder->mb_name, "INBOX")==0 ) {
@@ -312,11 +318,16 @@ static int init_chat_folders__(mrimap_t* ths)
 
 	free(ths->m_moveto_folder);
 	ths->m_moveto_folder = NULL;
-
+	//this sets ths->m_imap_delimiter as side-effect
 	folder_list = list_folders__(ths);
+
+	//as a fallback, the chats_folder is created under INBOX as required e.g. for DomainFactory
+	char fallback_folder[64];
+	snprintf(fallback_folder, sizeof(fallback_folder), "INBOX%c%s", ths->m_imap_delimiter, MR_CHATS_FOLDER);
+
 	for( iter1 = clist_begin(folder_list); iter1 != NULL ; iter1 = clist_next(iter1) ) {
 		mrimapfolder_t* folder = (struct mrimapfolder_t*)clist_content(iter1);
-		if( strcmp(folder->m_name_utf8, MR_CHATS_FOLDER)==0 || strcmp(folder->m_name_utf8, MR_CHATS_FOLDER_FALLBACK)==0 ) {
+		if( strcmp(folder->m_name_utf8, MR_CHATS_FOLDER)==0 || strcmp(folder->m_name_utf8, fallback_folder)==0 ) {
 			chats_folder = safe_strdup(folder->m_name_to_select);
 			break;
 		}
@@ -333,13 +344,13 @@ static int init_chat_folders__(mrimap_t* ths)
 		int r = mailimap_create(ths->m_hEtpan, MR_CHATS_FOLDER);
 		if( is_error(ths, r) ) {
 			mrmailbox_log_warning(ths->m_mailbox, 0, "Cannot create IMAP-folder, using trying INBOX subfolder.");
-			r = mailimap_create(ths->m_hEtpan, MR_CHATS_FOLDER_FALLBACK);
+			r = mailimap_create(ths->m_hEtpan, fallback_folder);
 			if( is_error(ths, r) ) {
 				/* continue on errors, we'll just use a different folder then */
 				mrmailbox_log_warning(ths->m_mailbox, 0, "Cannot create IMAP-folder, using default.");
 			}
 			else {
-				chats_folder = safe_strdup(MR_CHATS_FOLDER_FALLBACK);
+				chats_folder = safe_strdup(fallback_folder);
 				mrmailbox_log_info(ths->m_mailbox, 0, "IMAP-folder created (inbox subfolder).");
 			}
 		}

--- a/src/mrimap.h
+++ b/src/mrimap.h
@@ -68,6 +68,7 @@ typedef struct mrimap_t
 	int                   m_has_xlist;
 	char*                 m_moveto_folder;/* Folder, where reveived chat messages should go to.  Normally "Chats" but may be NULL to leave them in the INBOX */
 	char*                 m_sent_folder;  /* Folder, where send messages should go to.  Normally "Chats". */
+	char                  m_imap_delimiter;/* IMAP Path separator. Set as a side-effect in list_folders__ */
 	pthread_mutex_t       m_idlemutex;    /* set, if idle is not possible; morover, the interrupted IDLE thread waits a second before IDLEing again; this allows several jobs to be executed */
 	pthread_mutex_t       m_inwait_mutex; /* only used to wait for mailstream_wait_idle()/mailimap_idle_done() to terminate. */
 


### PR DESCRIPTION
Instead of using hardcoded `INBOX.Chats` as fallback if `Chats` can't be created (#173) we detect the IMAP folder-delimiter as part of the list folders process and use this to construct the fallback folder name.

Please review if I did everything correct with C strings, because I am not that familiar with C and don't want to introduce security holes.