### PR TITLE
Workaround for hMail. Fixes deltachat/deltachat-android#67

### DIFF
--- a/src/mrsmtp.c
+++ b/src/mrsmtp.c
@@ -19,7 +19,7 @@
  *
  ******************************************************************************/
 
-
+#include <unistd.h>
 #include <libetpan/libetpan.h>
 #include "mrmailbox_internal.h"
 #include "mrsmtp.h"
@@ -196,8 +196,26 @@ int mrsmtp_connect(mrsmtp_t* ths, const mrloginparam_t* lp)
 			mrmailbox_log_info(ths->m_mailbox, 0, "Login to SMTP-server as \"%s\"...", lp->m_send_user);
 
 				if((r=mailsmtp_auth(ths->m_hEtpan, lp->m_send_user, lp->m_send_pw))!=MAILSMTP_NO_ERROR ) {
-					mrmailbox_log_error_if(&ths->m_log_connect_errors, ths->m_mailbox, 0, "SMTP-login failed for user %s (%s)", lp->m_send_user, mailsmtp_strerror(r));
-					goto cleanup;
+					/* 
+					 * There are some Mailservers which do not correclty implement PLAIN auth (hMail)
+					 * So here we try a workaround. See https://github.com/deltachat/deltachat-android/issues/67
+					 */
+					if (ths->m_hEtpan->auth & MAILSMTP_AUTH_PLAIN) {
+						mrmailbox_log_info(ths->m_mailbox, 0, "Trying SMTP-Login workaround \"%s\"...", lp->m_send_user);
+						int err;
+						char hostname[513];
+
+						err = gethostname(hostname, sizeof(hostname));
+						if (err < 0) {
+							return MAILSMTP_ERROR_MEMORY;
+						}
+						r = mailesmtp_auth_sasl(ths->m_hEtpan, "PLAIN", hostname, NULL, NULL, NULL, lp->m_send_user, lp->m_send_pw, NULL);
+					}
+					if (r != MAILSMTP_NO_ERROR)
+					{
+						mrmailbox_log_error_if(&ths->m_log_connect_errors, ths->m_mailbox, 0, "SMTP-login failed for user %s (%s)", lp->m_send_user, mailsmtp_strerror(r));
+						goto cleanup;
+					}
 				}
 
 			mrmailbox_log_info(ths->m_mailbox, 0, "SMTP-Login ok.");

--- a/src/mrsmtp.c
+++ b/src/mrsmtp.c
@@ -207,7 +207,8 @@ int mrsmtp_connect(mrsmtp_t* ths, const mrloginparam_t* lp)
 
 						err = gethostname(hostname, sizeof(hostname));
 						if (err < 0) {
-							return MAILSMTP_ERROR_MEMORY;
+							mrmailbox_log_error(ths->m_mailbox, 0, "SMTP-Login: Cannot get hostname.");
+							goto cleanup;
 						}
 						r = mailesmtp_auth_sasl(ths->m_hEtpan, "PLAIN", hostname, NULL, NULL, NULL, lp->m_send_user, lp->m_send_pw, NULL);
 					}


### PR DESCRIPTION
This commit retries the SMTP login if the method is PLAIN and it failed. See deltachat/deltachat-android#67 for details.