### PR TITLE
Rename Chats folder to DeltaChats. Fixes #47

### DIFF
--- a/src/mrchat-private.h
+++ b/src/mrchat-private.h
@@ -61,7 +61,8 @@ int             mrchat_are_all_members_verified__ (mrchat_t*);
 
 
 #define         MR_CHAT_PREFIX              "Chat:"      /* you MUST NOT modify this or the following strings */
-#define         MR_CHATS_FOLDER             "Chats"      /* if we want to support Gma'l-labels - "Chats" is a reserved word for Gma'l */
+#define         MR_CHATS_FOLDER             "DeltaChats" /* Folder where the Chats will be moved to */
+#define         MR_CHATS_FOLDER_LEGACY      "Chats"      /* Folder name in old version. Will be renamed to new folder if present */
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This renames the Chats folder to DeltaChats and thus should fix #47 and some other issues (gmail, yahoo).
IMHO it makes the function somewhat hard to read, so feel free to refactor before merging.
I just did a quick test on my domainfactory account:
I just upgraded my existing Android install and after I sent the first message, it successfully renamed the old Chats folder to DeltaChats (under Inbox).
However, now I have a dead Chats folder in Thunderbird which cannot be deleted, because it does not exist ;).