### PR TITLE
Fix etpan deps creation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,18 +18,11 @@ etpan_cflags = run_command('libetpan-config', ['--cflags']).stdout().strip().spl
 etpan_libs = run_command('libetpan-config', ['--libs']).stdout().strip().split()
 etpan_inc_dir = join_paths(etpan_prefix, 'include')
 etpan_inc = include_directories(etpan_inc_dir)
-if etpan_cflags == ''
-  etpan = declare_dependency(
-    include_directories: etpan_inc,
-    link_args: etpan_libs,
-  )
-else
-  etpan = declare_dependency(
-    compile_args: etpan_cflags,
-    include_directories: etpan_inc,
-    link_args: etpan_libs,
-  )
-endif
+etpan = declare_dependency(
+  compile_args: etpan_cflags,
+  include_directories: etpan_inc,
+  link_args: etpan_libs,
+)
 
 # Build bundled dependencies.
 netpgp_proj = subproject('netpgp')


### PR DESCRIPTION
This was comparing a list with a string, which will start failing in
the future (as it should!).  But there's simply no need for this,
declare_dependency() function is quite happy with an empty list for
argument.  This was probably a leftover from an earlier attempt to get
things working.