### PR TITLE
Update python bindings to new headers naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ po/*.insert-header
 
 # ignore other files
 .DS_Store
+capi.abi3.so
 
 # ignore build directory
 builddir/
+python/build

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -10,7 +10,7 @@ def ffibuilder():
     builder.set_source(
         'deltachat.capi',
         """
-            #include <deltachat/mrmailbox.h>
+            #include <deltachat/deltachat.h>
         """,
         libraries=['deltachat'],
     )
@@ -21,7 +21,7 @@ def ffibuilder():
     cc = distutils.ccompiler.new_compiler(force=True)
     distutils.sysconfig.customize_compiler(cc)
     with tempfile.NamedTemporaryFile(mode='w', suffix='.h') as src_fp:
-        src_fp.write('#include <deltachat/mrmailbox.h>')
+        src_fp.write('#include <deltachat/deltachat.h>')
         src_fp.flush()
         with tempfile.NamedTemporaryFile(mode='r') as dst_fp:
             cc.preprocess(source=src_fp.name,

--- a/python/tests/test_mrmailbox.py
+++ b/python/tests/test_mrmailbox.py
@@ -5,12 +5,6 @@ import pytest
 from deltachat import capi
 
 
-@pytest.fixture
-def tmppath(tmpdir):
-    return pathlib.Path(tmpdir.strpath)
-
-
-def test_new():
-    mbox = capi.lib.mrmailbox_new(capi.ffi.NULL, capi.ffi.NULL, capi.ffi.NULL)
-    capi.lib.mrmailbox_close(mbox)
-    assert 0
+def test_empty_context():
+    ctx = capi.lib.dc_context_new(capi.ffi.NULL, capi.ffi.NULL, capi.ffi.NULL)
+    capi.lib.dc_close(ctx)

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -27,8 +27,10 @@ extern "C" {
 #endif
 
 
+#ifndef PY_CFFI
 #include <stdint.h>
 #include <time.h>
+#endif
 
 
 #define DC_VERSION_STR "0.19.0"


### PR DESCRIPTION
This fixes the python bindings build to work with the new layout of
the header files and new names.