### PR TITLE
Add option to add a special marker for "All done" to the chatlist

### DIFF
--- a/src/dc_chatlist.c
+++ b/src/dc_chatlist.c
@@ -379,6 +379,10 @@ static int dc_chatlist_load_from_db(dc_chatlist_t* chatlist, int listflags, cons
 
     if (add_archived_link_item && dc_get_archived_cnt(chatlist->context)>0)
     {
+		if (dc_array_get_cnt(chatlist->chatNlastmsg_ids)==0 && (listflags & DC_GCL_ADD_ALLDONE_HINT)) {
+			dc_array_add_id(chatlist->chatNlastmsg_ids, DC_CHAT_ID_ALLDONE_HINT);
+			dc_array_add_id(chatlist->chatNlastmsg_ids, 0);
+		}
 		dc_array_add_id(chatlist->chatNlastmsg_ids, DC_CHAT_ID_ARCHIVED_LINK);
 		dc_array_add_id(chatlist->chatNlastmsg_ids, 0);
     }
@@ -432,6 +436,9 @@ int dc_get_archived_cnt(dc_context_t* context)
  *   "Show archived chats", if the user clicks this item, the UI should show a
  *   list of all archived chats that can be created by this function hen using
  *   the DC_GCL_ARCHIVED_ONLY flag.
+ * - DC_CHAT_ID_ALLDONE_HINT (7) - this special chat is present
+ *   if DC_GCL_ADD_ALLDONE_HINT is added to listflags
+ *   and if there are only archived chats.
  *
  * @memberof dc_context_t
  * @param context The context object as returned by dc_context_new()
@@ -443,6 +450,8 @@ int dc_get_archived_cnt(dc_context_t* context)
  *     - if the flag DC_GCL_NO_SPECIALS is set, deaddrop and archive link are not added
  *       to the list (may be used eg. for selecting chats on forwarding, the flag is
  *       not needed when DC_GCL_ARCHIVED_ONLY is already set)
+ *     - if the flag DC_GCL_ADD_ALLDONE_HINT is set, DC_CHAT_ID_ALLDONE_HINT
+ *       is added as needed.
  * @param query_str An optional query for filtering the list.  Only chats matching this query
  *     are returned.  Give NULL for no filtering.
  * @param query_id An optional contact ID for filtering the list.  Only chats including this contact ID

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -255,6 +255,7 @@ void            dc_interrupt_smtp_idle       (dc_context_t*);
 // handle chatlists
 #define         DC_GCL_ARCHIVED_ONLY         0x01
 #define         DC_GCL_NO_SPECIALS           0x02
+#define         DC_GCL_ADD_ALLDONE_HINT      0x04
 dc_chatlist_t*  dc_get_chatlist              (dc_context_t*, int flags, const char* query_str, uint32_t query_id);
 
 
@@ -431,6 +432,7 @@ typedef struct _dc_chat dc_chat_t;
 #define         DC_CHAT_ID_MSGS_IN_CREATION  4 // a message is just in creation but not yet assigned to a chat (eg. we may need the message ID to set up blobs; this avoids unready message to be sent and shown)
 #define         DC_CHAT_ID_STARRED           5 // virtual chat showing all messages flagged with msgs.starred=2
 #define         DC_CHAT_ID_ARCHIVED_LINK     6 // only an indicator in a chatlist
+#define         DC_CHAT_ID_ALLDONE_HINT      7 // only an indicator in a chatlist
 #define         DC_CHAT_ID_LAST_SPECIAL      9 // larger chat IDs are "real" chats, their messages are "real" messages.
 
 


### PR DESCRIPTION
this is a helper for the UI creating the chatlist.

already today, the chatlist consist out of normal chats identified by an ID _plus_ some special IDs representing special items. currently, these items are the "Archive" link and the "Contact requests".

UIs as the new signal port show a help-hint if everything is archived (sth. as _"well done, nothing more to do ... you have a zero inbox"_. to help these UIs adding such an item to the virtual "recycler" view - which is typically complicated enough - this pr offers an option to easily add such an item as needed:
 
if the flag `DC_GCL_ADD_ALLDONE_HINT` is given to `dc_get_chatlist()` and there are no but archived chats, the item `DC_CHAT_ID_ALLDONE` is added; typically together with the "Archive" link.
