### PR TITLE
 introduce attr / refine GC handling

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ def main():
         long_description = long_description,
         author='Delta Chat contributors',
         setup_requires=['cffi>=1.0.0'],
-        install_requires=['cffi>=1.0.0', 'requests'],
+        install_requires=['cffi>=1.0.0', 'requests', 'attr'],
         packages=setuptools.find_packages('src'),
         package_dir={'': 'src'},
         cffi_modules=['src/deltachat/_build.py:ffibuilder'],

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -13,7 +13,13 @@ def py_dc_callback(ctx, evt, data1, data2):
     CFFI only allows us to set one global event handler, so this one
     looks up the correct event handler for the given context.
     """
-    callback = _DC_CALLBACK_MAP.get(ctx, lambda *a: 0)
+    try:
+        callback = _DC_CALLBACK_MAP.get(ctx, lambda *a: 0)
+    except AttributeError:
+        # we are in a deep in GC-free/interpreter shutdown land
+        # nothing much better to do here than:
+        return 0
+
     # the following code relates to the deltachat/_build.py's helper
     # function which provides us signature info of an event call
     evt_name = get_dc_event_name(evt)

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -10,12 +10,14 @@ except ImportError:
 import deltachat
 from . import capi
 from .capi import ffi
-from .myattr import attrib_CData, attrs, attrib_int, cached_property
+from .types import cached_property
+import attr
+from attr import validators as v
 
 
-@attrs
+@attr.s
 class EventHandler(object):
-    dc_context = attrib_CData()
+    dc_context = attr.ib(validator=v.instance_of(ffi.CData))
 
     def read_url(self, url):
         try:
@@ -76,10 +78,10 @@ class EventLogger:
                  tname, self.logid, evt_name, data1, data2))
 
 
-@attrs
+@attr.s
 class Contact(object):
-    dc_context = attrib_CData()
-    id = attrib_int()
+    dc_context = attr.ib(validator=v.instance_of(ffi.CData))
+    id = attr.ib(validator=v.instance_of(int))
 
     @cached_property  # only get it once because we only free it once
     def dc_contact_t(self):
@@ -105,10 +107,10 @@ class Contact(object):
         return capi.lib.dc_contact_is_verified(self.dc_contact_t)
 
 
-@attrs
+@attr.s
 class Chat(object):
-    dc_context = attrib_CData()
-    id = attrib_int()
+    dc_context = attr.ib(validator=v.instance_of(ffi.CData))
+    id = attr.ib(validator=v.instance_of(int))
 
     @cached_property
     def dc_chat_t(self):
@@ -125,10 +127,10 @@ class Chat(object):
         return Message(self.dc_context, msg_id)
 
 
-@attrs
+@attr.s
 class Message(object):
-    dc_context = attrib_CData()
-    id = attrib_int()
+    dc_context = attr.ib(validator=v.instance_of(ffi.CData))
+    id = attr.ib(validator=v.instance_of(int))
 
     @cached_property
     def dc_msg_t(self):

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -85,8 +85,8 @@ class Contact(object):
     def dc_contact_t(self):
         return capi.lib.dc_get_contact(self.dc_context, self.id)
 
-    def __del__(self):
-        capi.lib.dc_contact_unref(self.dc_contact_t)
+    def __del__(self, dc_contact_unref=capi.lib.dc_contact_unref):
+        dc_contact_unref(self.dc_contact_t)
 
     @property
     def addr(self):
@@ -134,8 +134,8 @@ class Message(object):
     def dc_msg_t(self):
         return capi.lib.dc_get_msg(self.dc_context, self.id)
 
-    def __del__(self):
-        capi.lib.dc_msg_unref(self.dc_msg_t)
+    def __del__(self, dc_msg_unref=capi.lib.dc_msg_unref):
+        dc_msg_unref(self.dc_msg_t)
 
     @property
     def text(self):

--- a/python/src/deltachat/myattr.py
+++ b/python/src/deltachat/myattr.py
@@ -1,0 +1,33 @@
+from attr import attrs, attrib  # noqa
+from attr import validators as v
+
+
+def attrib_int():
+    return attrib(validator=v.instance_of(int))
+
+
+def attrib_CData():
+    from deltachat.capi import ffi
+    return attrib(validator=v.instance_of(ffi.CData))
+
+
+# copied over unmodified from
+# https://github.com/devpi/devpi/blob/master/common/devpi_common/types.py
+# where it's also tested
+
+def cached_property(f):
+    """returns a cached property that is calculated by function f"""
+    def get(self):
+        try:
+            return self._property_cache[f]
+        except AttributeError:
+            self._property_cache = {}
+        except KeyError:
+            pass
+        x = self._property_cache[f] = f(self)
+        return x
+
+    def set(self, val):
+        propcache = self.__dict__.setdefault("_property_cache", {})
+        propcache[f] = val
+    return property(get, set)

--- a/python/src/deltachat/types.py
+++ b/python/src/deltachat/types.py
@@ -1,19 +1,6 @@
-from attr import attrs, attrib  # noqa
-from attr import validators as v
-
-
-def attrib_int():
-    return attrib(validator=v.instance_of(int))
-
-
-def attrib_CData():
-    from deltachat.capi import ffi
-    return attrib(validator=v.instance_of(ffi.CData))
-
-
 # copied over unmodified from
 # https://github.com/devpi/devpi/blob/master/common/devpi_common/types.py
-# where it's also tested
+
 
 def cached_property(f):
     """returns a cached property that is calculated by function f"""

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -29,6 +29,13 @@ class TestOfflineAccount:
         assert chat == chat2
         assert not (chat != chat2)
 
+    def test_message(self, acfactory):
+        ac1 = acfactory.get_offline_account()
+        contact1 = ac1.create_contact("some1@hello.com", name="some1")
+        chat = ac1.create_chat_by_contact(contact1)
+        msg = chat.send_text_message("msg1")
+        assert msg
+
 
 class TestOnlineAccount:
     def wait_successful_IMAP_SMTP_connection(self, account):
@@ -74,14 +81,14 @@ class TestOnlineAccount:
         self.wait_successful_IMAP_SMTP_connection(ac2)
         self.wait_configuration_progress(ac1, 1000)
         self.wait_configuration_progress(ac2, 1000)
-        msg_id = chat.send_text_message("msg1")
+        msg = chat.send_text_message("msg1")
         ev = ac1._evlogger.get_matching("DC_EVENT_MSG_DELIVERED")
         evt_name, data1, data2 = ev
         assert data1 == chat.id
-        assert data2 == msg_id
+        assert data2 == msg.id
         ev = ac2._evlogger.get_matching("DC_EVENT_MSGS_CHANGED")
-        assert ev[2] == msg_id
-        msg = ac2.get_message(msg_id)
+        assert ev[2] == msg.id
+        msg = ac2.get_message_by_id(msg.id)
         assert msg.text == "msg1"
         # note that ev[1] aka data1 contains a bogus channel id
         # probably should just not get passed from the core

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -28,6 +28,7 @@ class TestOfflineAccount:
         assert chat2.id == chat.id
         assert chat == chat2
         assert not (chat != chat2)
+        assert chat.dc_chat_t
 
     def test_message(self, acfactory):
         ac1 = acfactory.get_offline_account()

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -12,6 +12,7 @@ commands = pytest {posargs:tests}
 usedevelop = True
 deps = 
     pytest
+    pytest-faulthandler
     pdbpp
 
 [testenv:lint]


### PR DESCRIPTION
address #273 -- also refine the GC-handling of contact and message pointers.
free-ing dc_context pointers kind of works now -- but without calling account.shutdown() first 
then GC ``__del__`` calls could end up without access to globals. Refining/reviewing GC handling should mostly be part of a separate effort than this PR.  The current PR is at least an improvement. 