### PR TITLE
lookup contacts

### DIFF
--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -359,6 +359,20 @@ void stress_functions(dc_context_t* context)
 	 **************************************************************************/
 
 	{
+		assert( !dc_may_be_valid_addr(NULL) );
+		assert( !dc_may_be_valid_addr("") );
+		assert(  dc_may_be_valid_addr("user@domain.tld") );
+		assert( !dc_may_be_valid_addr("uuu") );
+		assert( !dc_may_be_valid_addr("dd.tt") );
+		assert( !dc_may_be_valid_addr("tt.dd@uu") );
+		assert( !dc_may_be_valid_addr("uu") );
+		assert( !dc_may_be_valid_addr("u@d") );
+		assert( !dc_may_be_valid_addr("u@d.") );
+		assert( !dc_may_be_valid_addr("u@d.t") );
+		assert(  dc_may_be_valid_addr("u@d.tt") );
+		assert( !dc_may_be_valid_addr("u@.tt") );
+		assert( !dc_may_be_valid_addr("@d.tt") );
+
 		char* str = strdup("aaa");
 		int replacements = dc_str_replace(&str, "a", "ab"); /* no endless recursion here! */
 		assert( strcmp(str, "ababab")==0 );

--- a/src/dc_aheader.c
+++ b/src/dc_aheader.c
@@ -109,7 +109,7 @@ static int add_attribute(dc_aheader_t* aheader, const char* name, const char* va
 	if (strcasecmp(name, "addr")==0)
 	{
 		if (value==NULL
-		 || strlen(value) < 3 || strchr(value, '@')==NULL || strchr(value, '.')==NULL /* rough check if email-address is valid */
+		 || !dc_may_be_valid_addr(value)
 		 || aheader->addr /* email already given */) {
 			return 0;
 		}

--- a/src/dc_qr.c
+++ b/src/dc_qr.c
@@ -192,7 +192,7 @@ dc_lot_t* dc_check_qr(dc_context_t* context, const char* qr)
 		char* temp = dc_urldecode(addr);      free(addr); addr = temp; /* urldecoding is needed at least for OPENPGP4FPR but should not hurt in the other cases */
 		      temp = dc_addr_normalize(addr); free(addr); addr = temp;
 
-		if (strlen(addr) < 3 || strchr(addr, '@')==NULL || strchr(addr, '.')==NULL) {
+		if (!dc_may_be_valid_addr(addr)) {
 			qr_parsed->state = DC_QR_ERROR;
 			qr_parsed->text1 = dc_strdup("Bad e-mail address.");
 			goto cleanup;

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -313,6 +313,8 @@ dc_msg_t*       dc_get_msg                   (dc_context_t*, uint32_t msg_id);
 
 
 // handle contacts
+int             dc_may_be_valid_addr         (const char* addr);
+uint32_t        dc_lookup_contact_id_by_addr (dc_context_t*, const char* addr);
 uint32_t        dc_create_contact            (dc_context_t*, const char* name, const char* addr);
 int             dc_add_address_book          (dc_context_t*, const char*);
 


### PR DESCRIPTION
added two functions:
- `dc_lookup_contact_id_by_addr()` checks if an e-mail-address is in the database (wondering that this function does not exist :)
- `dc_may_be_valid_addr()` is used internally to check addresses eg. given to dc_create_contact(). thought that i would need it for the new android port, however, it's not needed. nevertheless, it may be useful here and there - esp. as it is the same logic as used internally to validate addresses.

nb: the validation is rather generous, however, doing more complex regex things will increase problems but probably not solve some. validating email addresses "the right way" seems to be very hard, see eg. https://www.regular-expressions.info/email.html