### PR TITLE
test file functions with  only if there is a blobdir

### DIFF
--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -217,6 +217,7 @@ void stress_functions(dc_context_t* context)
 	/* test file functions
 	 **************************************************************************/
 
+	if (dc_is_open(context))
 	{
 		if (dc_file_exist(context, "$BLOBDIR/foobar")
 		 || dc_file_exist(context, "$BLOBDIR/dada")

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -1130,6 +1130,7 @@ int dc_get_filemeta(const void* buf_start, size_t buf_bytes, uint32_t* ret_width
 
 char* dc_get_abs_path(dc_context_t* context, const char* pathNfilename)
 {
+	int   success           = 0;
 	char* pathNfilename_abs = NULL;
 
 	if (context==NULL || pathNfilename==NULL) {
@@ -1139,10 +1140,19 @@ char* dc_get_abs_path(dc_context_t* context, const char* pathNfilename)
 	pathNfilename_abs = dc_strdup(pathNfilename);
 
 	if (strncmp(pathNfilename_abs, "$BLOBDIR", 8)==0) {
+		if (context->blobdir==NULL) {
+			goto cleanup;
+		}
 		dc_str_replace(&pathNfilename_abs, "$BLOBDIR", context->blobdir);
 	}
 
+	success = 1;
+
 cleanup:
+	if (!success) {
+		free(pathNfilename_abs);
+		pathNfilename_abs = NULL;
+	}
 	return pathNfilename_abs;
 }
 


### PR DESCRIPTION
moreover, if there is no  but it is shall be used, the corresponding function fail.

typically, this may only happen when testing the file functions directly - when using through the documented functions, there is always a blobdir if dc_open() succeeds. however, it is better, to have another security layer when creating the absolute pages.