### PR TITLE
add some more high-level API, and tests

### DIFF
--- a/python/conftest.py
+++ b/python/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 import re
 import threading
@@ -48,7 +49,7 @@ def acfactory(pytestconfig, tmpdir, request):
             configdict = self.configlist.pop(0)
             tmpdb = tmpdir.join("livedb%d" % self.live_count)
             ac = Account(tmpdb.strpath, logid="ac{}".format(self.live_count))
-            ac._evlogger.set_timeout(20)
+            ac._evlogger.set_timeout(30)
             ac.set_config(**configdict)
             if started:
                 ac.start()
@@ -61,3 +62,14 @@ def acfactory(pytestconfig, tmpdir, request):
 @pytest.fixture
 def tmp_db_path(tmpdir):
     return tmpdir.join("test.db").strpath
+
+
+@pytest.fixture
+def lp():
+    class Printer:
+        def sec(self, msg):
+            print()
+            print("=" * 10, msg, "=" * 10)
+        def step(self, msg):
+            print("-" * 5, "step " + msg, "-" * 5)
+    return Printer()

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -2,7 +2,7 @@ from deltachat import capi
 from deltachat.capi import ffi
 from deltachat.account import Account  # noqa
 
-__version__ = "0.5.dev2"
+__version__ = "0.5.dev3"
 
 
 _DC_CALLBACK_MAP = {}

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -144,6 +144,22 @@ class Account(object):
         chat_id = lib.dc_create_chat_by_msg_id(self._dc_context, msg_id)
         return Chat(self._dc_context, chat_id)
 
+    def get_chats(self):
+        """ return list of chats.
+
+        :returns: a list of :class:`Chat` objects.
+        """
+        dc_chatlist = ffi.gc(
+            lib.dc_get_chatlist(self._dc_context, 0, ffi.NULL, 0),
+            lib.dc_chatlist_unref
+        )
+
+        chatlist = []
+        for i in range(0, lib.dc_chatlist_get_cnt(dc_chatlist)):
+            chat_id = lib.dc_chatlist_get_chat_id(dc_chatlist, i)
+            chatlist.append(Chat(self._dc_context, chat_id))
+        return chatlist
+
     def get_message_by_id(self, msg_id):
         """ return Message instance. """
         return Message(self._dc_context, msg_id)

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -324,6 +324,7 @@ class EventLogger:
         return ev
 
     def get_matching(self, event_name_regex):
+        print ("-- waiting for event with regex:", event_name_regex, "--")
         rex = re.compile("(?:{}).*".format(event_name_regex))
         while 1:
             ev = self.get()

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -330,6 +330,13 @@ class EventLogger:
             if rex.match(ev[0]):
                 return ev
 
+    def get_info_matching(self, regex):
+        rex = re.compile("(?:{}).*".format(regex))
+        while 1:
+            ev = self.get_matching("DC_EVENT_INFO")
+            if rex.match(ev[2]):
+                return ev
+
     def _log_event(self, evt_name, data1, data2):
         # don't show events that are anyway empty impls now
         if evt_name in ("DC_EVENT_GET_STRING", "DC_EVENT_IS_OFFLINE"):

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -136,8 +136,8 @@ class Account(object):
         return Chat(self._dc_context, chat_id)
 
     def create_chat_by_message(self, message):
-        """ create or get an existing 1:1 chat object for the specified sender
-        of the specified message.
+        """ create or get an existing chat object for the
+        the specified message.
 
         :param message: messsage id or message instance.
         :returns: a :class:`Chat` object.
@@ -190,6 +190,16 @@ class Account(object):
             arr.append(msg)
         msg_ids = ffi.cast("uint32_t*", ffi.from_buffer(arr))
         lib.dc_markseen_msgs(self._dc_context, msg_ids, len(messages))
+
+    def forward_messages(self, messages, chat):
+        """ Forward list of messages to a chat.
+
+        :param messages: list of :class:`Message` object.
+        :param chat: :class:`Chat` object.
+        :returns: None
+        """
+        msg_ids = [msg.id for msg in messages]
+        lib.dc_forward_msgs(self._dc_context, msg_ids, len(msg_ids), chat.id)
 
     def start(self):
         """ configure this account object, start receiving events,

--- a/python/src/deltachat/chatting.py
+++ b/python/src/deltachat/chatting.py
@@ -77,8 +77,8 @@ class Chat(object):
 
     def set_name(self, name):
         """ set name of this chat. """
+        name = as_dc_charpointer(name)
         return lib.dc_set_chat_name(self._dc_context, self.id, name)
-
 
     # ------  chat messaging API ------------------------------
 

--- a/python/src/deltachat/chatting.py
+++ b/python/src/deltachat/chatting.py
@@ -150,7 +150,7 @@ class Chat(object):
         :returns: None
         """
         dc_array = ffi.gc(
-            lib.dc_get_contacts(self._dc_context, lib.DC_GCL_ADD_SELF, ffi.NULL),
+            lib.dc_get_chat_contacts(self._dc_context, self.id),
             lib.dc_array_unref
         )
         return list(iter_array(

--- a/python/src/deltachat/chatting.py
+++ b/python/src/deltachat/chatting.py
@@ -58,25 +58,37 @@ class Chat(object):
             lib.dc_chat_unref
         )
 
-    # ------  chat status API ------------------------------
+    # ------  chat status/metadata API ------------------------------
 
     def is_deaddrop(self):
-        """ return true if this chat is a deaddrop chat. """
+        """ return true if this chat is a deaddrop chat.
+
+        :returns: True if chat is the deaddrop chat, False otherwise.
+        """
         return self.id == lib.DC_CHAT_ID_DEADDROP
 
     def is_promoted(self):
         """ return True if this chat is promoted, i.e.
         the member contacts are aware of their membership,
         have been sent messages.
+
+        :returns: True if chat is promoted, False otherwise.
         """
         return not lib.dc_chat_is_unpromoted(self._dc_chat)
 
     def get_name(self):
-        """ return name of this chat. """
+        """ return name of this chat.
+
+        :returns: unicode name
+        """
         return from_dc_charpointer(lib.dc_chat_get_name(self._dc_chat))
 
     def set_name(self, name):
-        """ set name of this chat. """
+        """ set name of this chat.
+
+        :param: name as a unicode string.
+        :returns: None
+        """
         name = as_dc_charpointer(name)
         return lib.dc_set_chat_name(self._dc_context, self.id, name)
 

--- a/python/src/deltachat/cutil.py
+++ b/python/src/deltachat/cutil.py
@@ -10,12 +10,9 @@ def as_dc_charpointer(obj):
     return obj
 
 
-def iter_array_and_unref(dc_array_t, constructor):
-    try:
-        for i in range(0, lib.dc_array_get_cnt(dc_array_t)):
-            yield constructor(lib.dc_array_get_id(dc_array_t, i))
-    finally:
-        lib.dc_array_unref(dc_array_t)
+def iter_array(dc_array_t, constructor):
+    for i in range(0, lib.dc_array_get_cnt(dc_array_t)):
+        yield constructor(lib.dc_array_get_id(dc_array_t, i))
 
 
 def from_dc_charpointer(obj):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -54,6 +54,12 @@ class TestOfflineAccount:
         assert chat == chat2
         assert not (chat != chat2)
 
+        for ichat in ac1.get_chats():
+            if ichat.id == chat.id:
+                break
+        else:
+            pytest.fail("could not find chat")
+
     def test_message(self, acfactory):
         ac1 = acfactory.get_offline_account()
         contact1 = ac1.create_contact("some1@hello.com", name="some1")

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -60,6 +60,17 @@ class TestOfflineAccount:
         else:
             pytest.fail("could not find chat")
 
+    def test_group_chat(self, acfactory):
+        ac1 = acfactory.get_offline_account()
+        contact1 = ac1.create_contact("some1@hello.com", name="some1")
+        contact2 = ac1.create_contact("some2@hello.com", name="some2")
+        chat = ac1.create_group_chat(name="chat name")
+        chat.add_contact(contact1)
+        chat.add_contact(contact2)
+        assert contact1 in chat.get_contacts()
+        assert contact2 in chat.get_contacts()
+        assert not chat.is_promoted()
+
     def test_message(self, acfactory):
         ac1 = acfactory.get_offline_account()
         contact1 = ac1.create_contact("some1@hello.com", name="some1")

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -51,6 +51,7 @@ class TestOfflineAccount:
 
         chat2 = ac1.create_chat_by_contact(contact1.id)
         assert chat2.id == chat.id
+        assert chat2.get_name() == chat.get_name()
         assert chat == chat2
         assert not (chat != chat2)
 
@@ -60,16 +61,19 @@ class TestOfflineAccount:
         else:
             pytest.fail("could not find chat")
 
-    def test_group_chat(self, acfactory):
+    def test_group_chat_creation(self, acfactory):
         ac1 = acfactory.get_offline_account()
         contact1 = ac1.create_contact("some1@hello.com", name="some1")
         contact2 = ac1.create_contact("some2@hello.com", name="some2")
-        chat = ac1.create_group_chat(name="chat name")
+        chat = ac1.create_group_chat(name="title1")
         chat.add_contact(contact1)
         chat.add_contact(contact2)
+        assert chat.get_name() == "title1"
         assert contact1 in chat.get_contacts()
         assert contact2 in chat.get_contacts()
         assert not chat.is_promoted()
+        chat.set_name("title2")
+        assert chat.get_name() == "title2"
 
     def test_message(self, acfactory):
         ac1 = acfactory.get_offline_account()
@@ -145,11 +149,14 @@ class TestOnlineAccount:
         chat2 = msg_in.chat
         assert msg_in in chat2.get_messages()
         assert chat2.is_deaddrop()
+        assert chat2 == ac2.get_deaddrop_chat()
         chat3 = ac2.create_group_chat("newgroup")
         assert not chat3.is_promoted()
         ac2.forward_messages([msg_in], chat3)
         assert chat3.is_promoted()
-        assert chat3.get_messages()
+        messages = chat3.get_messages()
+        ac2.delete_messages(messages)
+        assert not chat3.get_messages()
 
     def test_send_and_receive_message(self, acfactory):
         ac1 = acfactory.get_live_account()


### PR DESCRIPTION
- refactor gc-handling wrt to array
- don't cache dc_chat and dc_msg and dc_contact structs -- "if in doubt, don't cache" as the wise programmers say. and i am not sure we need it.  the caching was also there to handle GC things but now that we have "ffi.gc()" we don't need that 
- add some high level APIs (forwarding messages, setting chat names, creating group chats and getting all chats ... but the latter are very simple chats for now, do not expose the full underlying API)
- improve some doc strings


