### PR TITLE
explicitly handle empty strings received from the UI on DC_EVENT_HTTP_GET

### DIFF
--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -38,12 +38,16 @@
 static char* read_autoconf_file(dc_context_t* context, const char* url)
 {
 	char* filecontent = NULL;
+
 	dc_log_info(context, 0, "Testing %s ...", url);
+
 	filecontent = (char*)context->cb(context, DC_EVENT_HTTP_GET, (uintptr_t)url, 0);
-	if (filecontent==NULL) {
+	if (filecontent==NULL || filecontent[0]==0) {
+		free(filecontent);
 		dc_log_info(context, 0, "Can't read file."); /* this is not a warning or an error, we're just testing */
 		return NULL;
 	}
+
 	return filecontent;
 }
 

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -1059,7 +1059,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  *     Response headers, encodings etc. must be stripped, only the raw file, which may be binary, should be returned.
  *     CAVE: The string will be free()'d by the core,
  *     so make sure it is allocated using malloc() or a compatible function.
- *     If you cannot provide the content, just return 0.
+ *     If you cannot provide the content, just return 0 or an empty string.
  */
 #define DC_EVENT_HTTP_GET                 2100
 


### PR DESCRIPTION
up to now, "Cannot read file" errors are only printed when DC_EVENT_HTTP_GET returns NULL.
if an empty string was returned, deltachat-core tries to parse this as xml content - which, of course, also results in an error some time later.

from the view of deltachat-core, there is no need to distinguish between NULL or an empty string.

so, this pr accepts empty strings explicitly as an error and also documents be behavior so that it is easier for bindings to return this error state.

@ralphtheninja when this is merged, i think we can remove the explicit handling of empty stirngs in [dcn_set_http_get_response](https://github.com/deltachat/deltachat-node/blob/master/src/module.c#L1331)