### PR TITLE
improve some msgs-changed events

### DIFF
--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1724,6 +1724,10 @@ void dc_delete_msgs(dc_context_t* context, const uint32_t* msg_ids, int msg_cnt)
 		}
 
 	dc_sqlite3_commit(context->sql);
+
+	if (msg_cnt) {
+		context->cb(context, DC_EVENT_MSGS_CHANGED, 0, 0);
+	}
 }
 
 

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -43,9 +43,10 @@ safe. However, there are some points to keep in mind:
    Transaction cannot be nested, we recommend to use them only in the
    top-level functions or not to use them.
 
-3. Using sqlite3_last_insert_rowid() causes race conditions (between the query
-   and the call another thread may insert a row.  This function MUST NOT be
-   used; dc_sqlite3_get_rowid() provides an alternative. */
+3. Using sqlite3_last_insert_rowid() and sqlite3_changes() cause race conditions
+   (between the query and the call another thread may insert or update a row.
+   These functions MUST NOT be used;
+   dc_sqlite3_get_rowid() provides an alternative. */
 
 
 void dc_sqlite3_log_error(dc_sqlite3_t* sql, const char* msg_format, ...)


### PR DESCRIPTION
- send DC_EVENT_MSGS_CHANGED on marking as noticed only on changes:

typically, the UI calls dc_marknoticed_chat()  whenever a chat is opened and reacts on a redraw when the DC_EVENT_MSGS_CHANGED is received. this change avoids superfluous redraws.

- send DC_EVENT_MSGS_CHANGED on deletion of messages

this was just missing :)