### PR TITLE
suspend smtp-thread by waiting-for-job-finish instead of entering-idle

### DIFF
--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -77,8 +77,8 @@ struct _dc_context
 	pthread_cond_t   smtpidle_cond;
 	pthread_mutex_t  smtpidle_condmutex;
 	int              smtpidle_condflag;
-	int              smtpidle_suspend;
-	int              smtpidle_in_idleing;
+	int              smtp_suspended;
+	int              smtp_doing_jobs;
 	#define          DC_JOBS_NEEDED_AT_ONCE   1
 	#define          DC_JOBS_NEEDED_AVOID_DOS 2
 	int              perform_smtp_jobs_needed;


### PR DESCRIPTION
to allow dc_configure() being called without the threads being started, we suspend the smtp-thread now by checking that we're not in performing jobs instead of waiting for entering idle.

closes #304 if being merged