### PR TITLE
let open return an error if there is already an opened database

### DIFF
--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -156,6 +156,10 @@ void dc_sqlite3_unref(dc_sqlite3_t* sql)
 
 int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 {
+	if (dc_sqlite3_is_open(sql)) {
+		return 0; // a cleanup would close the database
+	}
+
 	if (sql==NULL || dbfile==NULL) {
 		goto cleanup;
 	}


### PR DESCRIPTION
let open return an error if there is already an opened database, fixes #308 and relates to https://github.com/deltachat/deltachat-desktop/issues/61