### PR TITLE
Make more use of apt addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ addons:
     - python3-pip
     - python3.5
     - g++-7
+    - python-apt
 
 before_install:
+  - sudo apt-add-repository -y ppa:libreoffice/ppa
   - export CC=gcc-7
   - export CXX=g++-7
   - sudo ln -sf /usr/bin/python3.5 /usr/bin/python3
@@ -27,9 +29,8 @@ before_install:
 
 install:
   - sudo apt install -y libssl-dev libsqlite3-dev libbz2-dev zlib1g-dev python3.5-dev python-software-properties
-  - sudo apt-add-repository -y ppa:libreoffice/ppa
-  - sudo apt update 
-  - sudo apt install -y doxygen 
+  - sudo apt update
+  - sudo apt install -y doxygen
 
 script:
   - mkdir -p builddir && cd builddir && meson && ninja -v && sudo ninja install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,20 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - sourceline: 'ppa:libreoffice/ppa'
     packages:
     - python3-pip
     - python3.5
     - g++-7
-    - python-apt
+    - libssl-dev
+    - libsqlite3-dev
+    - libbz2-dev
+    - zlib1g-dev
+    - python3.5-dev
+    - python-software-properties
+    - doxygen
 
-before_install:
-  - sudo apt-add-repository -y ppa:libreoffice/ppa
+install:
   - export CC=gcc-7
   - export CXX=g++-7
   - sudo ln -sf /usr/bin/python3.5 /usr/bin/python3
@@ -27,12 +33,8 @@ before_install:
   - tar xfv cyrus-sasl2_2.1.27~101-g0780600+dfsg.orig.tar.xz
   - pushd cyrus-sasl2-2.1.27~101-g0780600+dfsg.orig && ./autogen.sh && make && sudo make install && popd
 
-install:
-  - sudo apt install -y libssl-dev libsqlite3-dev libbz2-dev zlib1g-dev python3.5-dev python-software-properties
-  - sudo apt update
-  - sudo apt install -y doxygen
-
 script:
+  - doxygen --version
   - mkdir -p builddir && cd builddir && meson && ninja -v && sudo ninja install
   - export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
   - sudo ldconfig -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     - python3-pip
     - python3.5
     - g++-7
-    - doxygen
 
 before_install:
   - export CC=gcc-7
@@ -27,7 +26,10 @@ before_install:
   - pushd cyrus-sasl2-2.1.27~101-g0780600+dfsg.orig && ./autogen.sh && make && sudo make install && popd
 
 install:
-  - sudo apt install -y libssl-dev libsqlite3-dev libbz2-dev zlib1g-dev python3.5-dev
+  - sudo apt install -y libssl-dev libsqlite3-dev libbz2-dev zlib1g-dev python3.5-dev python-software-properties
+  - sudo apt-add-repository -y ppa:libreoffice/ppa
+  - sudo apt update 
+  - sudo apt install -y doxygen 
 
 script:
   - mkdir -p builddir && cd builddir && meson && ninja -v && sudo ninja install


### PR DESCRIPTION
This builds on top of #321 .

Instead of having a install step that fetches apt packages we can just do all of this in the apt addon.
Also renamed the before_install step to install now.