### PR TITLE
use tilde instead of backtick for code fencing

### DIFF
--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -780,12 +780,12 @@ cleanup:
  * There is no need to call this every program start, the result is saved in the
  * database and you can use the connection directly:
  *
- * ```
+ * ~~~
  * if (!dc_is_configured(context)) {
  *     dc_configure(context);
  *     // wait for progress events
  * }
- * ```
+ * ~~~
  */
 void dc_configure(dc_context_t* context)
 {

--- a/src/dc_imex.c
+++ b/src/dc_imex.c
@@ -421,10 +421,10 @@ char* dc_normalize_setup_code(dc_context_t* context, const char* in)
  * Initiate Autocrypt Setup Transfer.
  * Before starting the setup transfer with this function, the user should be asked:
  *
- * ```
+ * ~~~
  * "An 'Autocrypt Setup Message' securely shares your end-to-end setup with other Autocrypt-compliant apps.
  * The setup will be encrypted by a setup code which is displayed here and must be typed on the other device.
- * ```
+ * ~~~
  *
  * After that, this function should be called to send the Autocrypt Setup Message.
  * The function creates the setup message and waits until it is really sent.
@@ -433,13 +433,13 @@ char* dc_normalize_setup_code(dc_context_t* context, const char* in)
  *
  * After everything succeeded, the required setup code is returned in the following format:
  *
- * ```
+ * ~~~
  * 1234-1234-1234-1234-1234-1234-1234-1234-1234
- * ```
+ * ~~~
  *
  * The setup code should be shown to the user then:
  *
- * ```
+ * ~~~
  * "Your key has been sent to yourself. Switch to the other device and
  * open the setup message. You should be prompted for a setup code. Type
  * the following digits into the prompt:
@@ -449,7 +449,7 @@ char* dc_normalize_setup_code(dc_context_t* context, const char* in)
  * 1234 - 1234 - 1234
  *
  * Once you're done, your other device will be ready to use Autocrypt."
- * ```
+ * ~~~
  *
  * On the _other device_ you will call dc_continue_key_transfer() then
  * for setup messages identified by dc_msg_is_setupmessage().
@@ -1242,7 +1242,7 @@ cleanup:
  *
  * Example:
  *
- * ```
+ * ~~~
  * char dir[] = "/dir/to/search/backups/in";
  *
  * void ask_user_for_credentials()
@@ -1276,7 +1276,7 @@ cleanup:
  *     }
  *     free(file);
  * }
- * ```
+ * ~~~
  *
  * @memberof dc_context_t
  * @param context The context as created by dc_context_new().

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -48,7 +48,7 @@ extern "C" {
  * specific events (eg. when the configuration is done or when fresh messages arrive).
  * With this function you can create a Delta Chat context then:
  *
- * ```
+ * ~~~
  * #include <deltachat.h>
  *
  * uintptr_t event_handler_func(dc_context_t* context, int event, uintptr_t data1, uintptr_t data2)
@@ -57,12 +57,12 @@ extern "C" {
  * }
  *
  * dc_context_t* context = dc_context_new(event_handler_func, NULL, NULL);
- * ```
+ * ~~~
  *
  * After that, you should make sure, sending and receiving jobs are processed as needed.
  * For this purpose, you have to **create two threads:**
  *
- * ```
+ * ~~~
  * #include <pthread.h>
  *
  * void* imap_thread_func(void* context)
@@ -85,7 +85,7 @@ extern "C" {
  * static pthread_t imap_thread, smtp_thread;
  * pthread_create(&imap_thread, NULL, imap_thread_func, context);
  * pthread_create(&smtp_thread, NULL, smtp_thread_func, context);
- * ```
+ * ~~~
  *
  * The example above uses "pthreads", however, you can also use anything else for thread handling.
  * NB: The deltachat-core library itself does not create any threads on its own, however, functions,
@@ -94,17 +94,17 @@ extern "C" {
  * After that you can  **define and open a database.** The database is a normal
  * sqlite-file and is created as needed:
  *
- * ```
+ * ~~~
  * dc_open(context, "example.db", NULL);
- * ```
+ * ~~~
  *
  * Now you can **configure the context:**
  *
- * ```
+ * ~~~
  * dc_set_config(context, "addr", "alice@example.org"); // use some real test credentials here
  * dc_set_config(context, "mail_pw", "***");
  * dc_configure(context);
- * ```
+ * ~~~
  *
  * dc_configure() returns immediately, the configuration itself may take a while and is done by a job
  * in the imap-thread you've defined above. Once done, the #DC_EVENT_CONFIGURE_PROGRESS reports
@@ -114,12 +114,12 @@ extern "C" {
  *
  * Now you can **send the first message:**
  *
- * ```
+ * ~~~
  * uint32_t contact_id = dc_create_contact(context, NULL, "bob@example.org"); // use a real testing address here
  * uint32_t chat_id    = dc_create_chat_by_contact_id(context, contact_id);
  *
  * dc_send_text_msg(context, chat_id, "Hi, here is my first message!");
- * ```
+ * ~~~
  *
  * dc_send_text_msg() returns immediately and the sending itself is done by a job
  * in the smtp-thread you've defined above. If you check the testing address (bob) and you should have received a normal email.
@@ -127,7 +127,7 @@ extern "C" {
  *
  * You can then **list all messages** of a chat as follow:
  *
- * ```
+ * ~~~
  * dc_array_t* msglist = dc_get_chat_msgs(context, chat_id, 0, 0);
  * for (int i = 0; i < dc_array_get_cnt(msglist); i++)
  * {
@@ -141,14 +141,14 @@ extern "C" {
  *     dc_msg_unref(msg);
  * }
  * dc_array_unref(msglist);
- * ```
+ * ~~~
  *
  * This will output the following two lines:
  *
- * ```
+ * ~~~
  * Message 1: Hi, here is my first message!
  * Message 2: Got it!
- * ```
+ * ~~~
  *
  *
  * ## Class reference


### PR DESCRIPTION
the reason is a better support for older doxygen versions, closes #323 
