### PR TITLE
disable transactions

### DIFF
--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -707,8 +707,12 @@ int dc_sqlite3_set_config_int(dc_sqlite3_t* sql, const char* key, int32_t value)
  ******************************************************************************/
 
 
+#undef USE_TRANSACTIONS
+
+
 void dc_sqlite3_begin_transaction(dc_sqlite3_t* sql)
 {
+#ifdef USE_TRANSACTIONS
 	// `BEGIN IMMEDIATE` ensures, only one thread may write.
 	// all other calls to `BEGIN IMMEDIATE` will try over until sqlite3_busy_timeout() is reached.
 	// CAVE: This also implies that transactions MUST NOT be nested.
@@ -717,24 +721,29 @@ void dc_sqlite3_begin_transaction(dc_sqlite3_t* sql)
 		dc_sqlite3_log_error(sql, "Cannot begin transaction.");
 	}
 	sqlite3_finalize(stmt);
+#endif
 }
 
 
 void dc_sqlite3_rollback(dc_sqlite3_t* sql)
 {
+#ifdef USE_TRANSACTIONS
 	sqlite3_stmt* stmt = dc_sqlite3_prepare(sql, "ROLLBACK;");
 	if (sqlite3_step(stmt) != SQLITE_DONE) {
 		dc_sqlite3_log_error(sql, "Cannot rollback transaction.");
 	}
 	sqlite3_finalize(stmt);
+#endif
 }
 
 
 void dc_sqlite3_commit(dc_sqlite3_t* sql)
 {
+#ifdef USE_TRANSACTIONS
 	sqlite3_stmt* stmt = dc_sqlite3_prepare(sql, "COMMIT;");
 	if (sqlite3_step(stmt) != SQLITE_DONE) {
 		dc_sqlite3_log_error(sql, "Cannot commit transaction.");
 	}
 	sqlite3_finalize(stmt);
+#endif
 }


### PR DESCRIPTION
currently, transactions are used at some places.
the transactions are _not_ needed to create compound statements that must not be executed imcomplete.
the transactions were only added in the hope that things should go faster.

however, esp. for threads, transactions have their complexity. eg. they must not be nested in the same thread and may fail if a transaction in another thread takes too much time, see also the [comment atop of dc_sqlite3.c](https://github.com/deltachat/deltachat-core/blob/master/src/dc_sqlite3.c#L28).

as i also do not see speed improvements worth this challenge, i would suggest to disable transations for now.