### PR TITLE
handle avatar image of user

### DIFF
--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -213,9 +213,16 @@ void* dc_get_userdata(dc_context_t* context)
  * The function is called by dc_config_set*() and by dc_open().
  *
  * @private @memberof dc_context_t
+ * @param context The context object as created by dc_context_new().
+ * @param key Name of the value to update, NULL to update all.
+ * @return None.
  */
 static void update_config_cache(dc_context_t* context, const char* key)
 {
+	if (context==NULL) {
+		return;
+	}
+
 	if (key==NULL || strcmp(key, "e2ee_enabled")==0) {
 		context->e2ee_enabled = dc_sqlite3_get_config_int(context->sql, "e2ee_enabled", DC_E2EE_DEFAULT_ENABLED);
 	}

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -461,15 +461,18 @@ char* dc_get_config(dc_context_t* context, const char* key, const char* def)
  */
 int dc_set_config_int(dc_context_t* context, const char* key, int32_t value)
 {
-	int ret = 0;
+	int   ret = 0;
+	char* value_str = NULL;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || key==NULL) {
-		return 0;
+		goto cleanup;
 	}
 
-	ret = dc_sqlite3_set_config_int(context->sql, key, value);
-	update_config_cache(context, key);
+	value_str = dc_mprintf("%i", (int)value);
+	ret = dc_set_config(context, key, value_str);
 
+cleanup:
+	free(value_str);
 	return ret;
 }
 


### PR DESCRIPTION
generally, we want the user to be able to set a profile image that is spreaded in some way to contacts. it is not yet decided how this should work in detail.

however, as a first step to this direction and as the android-dev ui needs a function to call just now, i've simply defined a setting that can be passed to `dc_set_config(context, "selfavatar", path)`.

the value is just an accessible path; the core makes a copy to the blob directory if needed and can use the file later, if required.

to get the avatar back, `dc_get_config(context, "selfavatar")`.

there is no need to adapt the bindings.

maybe this is sufficient, otherwise, we can refine this later as needed.