### PR TITLE
remove settings cache, and cast-settings-functions

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2035,9 +2035,13 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 		}
 	}
 
-	/* check if we can guarantee E2EE for this message.  If we can, we won't send the message without E2EE later (because of a reset, changed settings etc. - messages may be delayed significally if there is no network present) */
+	/* check if we can guarantee E2EE for this message.
+	if we guarantee E2EE, and circumstances change
+	so that E2EE is no longer available at a later point (reset, changed settings),
+	we do not send the message out at all */
 	int do_guarantee_e2ee = 0;
-	if (context->e2ee_enabled && dc_param_get_int(msg->param, DC_PARAM_FORCE_PLAINTEXT, 0)==0)
+	int e2ee_enabled = dc_sqlite3_get_config_int(context->sql, "e2ee_enabled", DC_E2EE_DEFAULT_ENABLED);
+	if (e2ee_enabled && dc_param_get_int(msg->param, DC_PARAM_FORCE_PLAINTEXT, 0)==0)
 	{
 		int can_encrypt = 1, all_mutual = 1; /* be optimistic */
 		stmt = dc_sqlite3_prepare(context->sql,

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -403,9 +403,6 @@ static char* get_sys_config_str(const char* key, const char* def)
  *                    NULL to remove the avatar.
  * - `e2ee_enabled` = 0=no end-to-end-encryption, 1=prefer end-to-end-encryption (default)
  *
- * If you want to set an integer, it may be easier to use dc_set_config_int(), however, it is also
- * fine to pass the integer as a string to this function.
- *
  * If you want to retrieve a value, use dc_get_config().
  *
  * @memberof dc_context_t
@@ -445,7 +442,6 @@ cleanup:
 
 /**
  * Get a configuration option. The configuration option is typically set by dc_set_config() or by the library itself.
- * To get an option as an integer, you can use dc_get_config_int() as an alternative.
  *
  * Moreover, this function can be used to query some global system values:
  *
@@ -486,50 +482,6 @@ char* dc_get_config(dc_context_t* context, const char* key, const char* def)
 	{
 		return dc_sqlite3_get_config(context->sql, key, def);
 	}
-}
-
-
-/**
- * Configure the context.  Similar to dc_set_config() but sets an integer instead of a string.
- * If there is already a key with a string set, this is overwritten by the given integer value.
- *
- * @memberof dc_context_t
- */
-int dc_set_config_int(dc_context_t* context, const char* key, int32_t value)
-{
-	int   ret = 0;
-	char* value_str = NULL;
-
-	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || key==NULL) {
-		goto cleanup;
-	}
-
-	value_str = dc_mprintf("%i", (int)value);
-	ret = dc_set_config(context, key, value_str);
-
-cleanup:
-	free(value_str);
-	return ret;
-}
-
-
-/**
- * Get a configuration option. Similar as dc_get_config() but gets the value as an integer instead of a string.
- *
- * @memberof dc_context_t
- */
-int32_t dc_get_config_int(dc_context_t* context, const char* key, int32_t def)
-{
-	if (key && key[0]=='s' && key[1]=='y' && key[2]=='s' && key[3]=='.') {
-		int def_returned = 0;
-		return get_sys_config_int(key, def, &def_returned);
-	}
-
-	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || key==NULL) {
-		return def;
-	}
-
-	return dc_sqlite3_get_config_int(context->sql, key, def);
 }
 
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -89,8 +89,6 @@ struct _dc_context
 
 	uint32_t         cmdline_sel_chat_id;   /**< Internal */
 
-	int              e2ee_enabled;          /**< Internal */
-
 	#define          DC_LOG_RINGBUF_SIZE 200
 	pthread_mutex_t  log_ringbuf_critical;  /**< Internal */
 	char*            log_ringbuf[DC_LOG_RINGBUF_SIZE];

--- a/src/dc_e2ee.c
+++ b/src/dc_e2ee.c
@@ -335,7 +335,7 @@ void dc_e2ee_encrypt(dc_context_t* context, const clist* recipients_addr,
 
 		/* init autocrypt header from db */
 		autocryptheader->prefer_encrypt = DC_PE_NOPREFERENCE;
-		if (context->e2ee_enabled) {
+		if (dc_sqlite3_get_config_int(context->sql, "e2ee_enabled", DC_E2EE_DEFAULT_ENABLED)) {
 			autocryptheader->prefer_encrypt = DC_PE_MUTUAL;
 		}
 

--- a/src/dc_imex.c
+++ b/src/dc_imex.c
@@ -592,10 +592,10 @@ static int set_self_key(dc_context_t* context, const char* armored, int set_defa
 	/* if we also received an Autocrypt-Prefer-Encrypt header, handle this */
 	if (buf_preferencrypt) {
 		if (strcmp(buf_preferencrypt, "nopreference")==0) {
-			dc_set_config_int(context, "e2ee_enabled", 0); /* use the top-level function as this also resets cached values */
+			dc_sqlite3_set_config_int(context->sql, "e2ee_enabled", 0);
 		}
 		else if (strcmp(buf_preferencrypt, "mutual")==0) {
-			dc_set_config_int(context, "e2ee_enabled", 1); /* use the top-level function as this also resets cached values */
+			dc_sqlite3_set_config_int(context->sql, "e2ee_enabled", 1);
 		}
 	}
 

--- a/src/dc_imex.c
+++ b/src/dc_imex.c
@@ -143,7 +143,8 @@ char* dc_render_setup_file(dc_context_t* context, const char* passphrase)
 			self_addr = dc_sqlite3_get_config(context->sql, "configured_addr", NULL);
 			dc_key_load_self_private(curr_private_key, self_addr, context->sql);
 
-			char* payload_key_asc = dc_key_render_asc(curr_private_key, context->e2ee_enabled? "Autocrypt-Prefer-Encrypt: mutual\r\n" : NULL);
+			int e2ee_enabled = dc_sqlite3_get_config_int(context->sql, "e2ee_enabled", DC_E2EE_DEFAULT_ENABLED);
+			char* payload_key_asc = dc_key_render_asc(curr_private_key, e2ee_enabled? "Autocrypt-Prefer-Encrypt: mutual\r\n" : NULL);
 			if (payload_key_asc==NULL) {
 				goto cleanup;
 			}

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -542,26 +542,12 @@ int dc_msg_get_duration(const dc_msg_t* msg)
  */
 int dc_msg_get_showpadlock(const dc_msg_t* msg)
 {
-	/* a padlock guarantees that the message is e2ee _and_ answers will be as well */
-	int show_encryption_state = 0;
-
 	if (msg==NULL || msg->magic!=DC_MSG_MAGIC || msg->context==NULL) {
 		return 0;
 	}
 
-	if (msg->context->e2ee_enabled) {
-		show_encryption_state = 1;
-	}
-	else {
-		dc_chat_t* chat = dc_get_chat(msg->context, msg->chat_id);
-		show_encryption_state = dc_chat_is_verified(chat);
-		dc_chat_unref(chat);
-	}
-
-	if (show_encryption_state) {
-		if (dc_param_get_int(msg->param, DC_PARAM_GUARANTEE_E2EE, 0)!=0) {
-			return 1;
-		}
+	if (dc_param_get_int(msg->param, DC_PARAM_GUARANTEE_E2EE, 0)!=0) {
+		return 1;
 	}
 
 	return 0;

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -231,8 +231,6 @@ char*           dc_get_blobdir               (const dc_context_t*);
 
 int             dc_set_config                (dc_context_t*, const char* key, const char* value);
 char*           dc_get_config                (dc_context_t*, const char* key, const char* def);
-int             dc_set_config_int            (dc_context_t*, const char* key, int32_t value);
-int32_t         dc_get_config_int            (dc_context_t*, const char* key, int32_t def);
 char*           dc_get_info                  (dc_context_t*);
 char*           dc_get_version_str           (void);
 void            dc_openssl_init_not_required (void);
@@ -678,7 +676,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  *
  * Flags for configuring IMAP and SMTP servers.
  * These flags are optional and may be set together with the username, password etc. via
- * dc_set_config() or dc_set_config_int() using the key "server_flags".
+ * dc_set_config() using the key "server_flags".
  *
  * @addtogroup DC_LP
  * @{


### PR DESCRIPTION
1. remove settings cache as discussd in irc today
2. remove cast-settings functions as discussed in #342 

moreover, the dc_msg_get_padlock() now just returns the encryption-state of the message and does no longer imply that subsequent messages will be encrypted, too (was never really understood this way, imho). 
the latter should can be done by a button on the send-button or so.

iirc, i discussed this with several people some time ago, however, as 1. touches this function i think it is a good moment to start with this. for the send button, i created a new issue #343