### PR TITLE
remove unnecessary assumptions about configured-state

### DIFF
--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -811,10 +811,6 @@ int dc_is_configured(const dc_context_t* context)
 		return 0;
 	}
 
-	if (dc_imap_is_connected(context->imap)) { /* if we're connected, we're also configured. this check will speed up the check as no database is involved */
-		return 1;
-	}
-
 	return dc_sqlite3_get_config_int(context->sql, "configured", 0)? 1 : 0;
 }
 

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -1311,7 +1311,7 @@ void dc_imap_disconnect(dc_imap_t* imap)
 
 int dc_imap_is_connected(const dc_imap_t* imap)
 {
-	return (imap && imap->connected); /* we do not use a LOCK - otherwise, the check may take seconds and is not sufficient for some GUI state updates. */
+	return (imap && imap->connected);
 }
 
 


### PR DESCRIPTION
we simplify the dc_is_configured() function to just check for the corresponding flag in the database.

this should be fast enough, esp. as the function is typically only called on program startup.

assumptions that an imap-connection always implies a correctly configured account may be wrong (eg. during configuration imap may be fine but smpt fails later on so that we're never configured although imap was working a while)