### PR TITLE
Normalize output from dc_get_info()

### DIFF
--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -555,43 +555,58 @@ char* dc_get_info(dc_context_t* context)
 	- use neutral speach; the Delta Chat Core is not directly related to any front end or end-product
 	- contributors: You're welcome to add your names here */
 	temp = dc_mprintf(
-		"Chats: %i\n"
-		"Chat messages: %i\n"
-		"Messages in contact requests: %i\n"
-		"Contacts: %i\n"
-		"Database=%s, dbversion=%i, Blobdir=%s\n"
-		"\n"
-		"displayname=%s\n"
-		"configured=%i\n"
-		"config0=%s\n"
-		"config1=%s\n"
+		"# key=value data\n"
+		"deltachat_core_version=v%s\n"
+		"sqlite_version=%s\n"
+		"sqlite_thread_safe=%i\n"
+		"libetpan_version=%i.%i\n"
+		"openssl_version=%i.%i.%i%c\n"
+		"compile_date=" __DATE__ ", " __TIME__ "\n"
+		"arch=%i\n"
+		"number_of_chats=%i\n"
+		"number_of_chat_messages=%i\n"
+		"messages_in_contact_requests=%i\n"
+		"number_of_contacts=%i\n"
+		"database_dir=%s\n"
+		"database_version=%i\n"
+		"blobdir=%s\n"
+		"display_name=%s\n"
+		"is_configured=%i\n"
+		"entered_account_settings=%s\n"
+		"used_account_settings=%s\n"
 		"mdns_enabled=%i\n"
 		"e2ee_enabled=%i\n"
-		"E2EE_DEFAULT_ENABLED=%i\n"
-		"Private keys=%i, public keys=%i, fingerprint=\n%s\n"
+		"e2ee_default_enabled=%i\n"
+		"private_key_count=%i\n"
+		"public_key_count=%i\n"
+		"fingerprint=%s\n"
 		"\n"
-		"Using Delta Chat Core v%s, SQLite %s-ts%i, libEtPan %i.%i, OpenSSL %i.%i.%i%c. Compiled " __DATE__ ", " __TIME__ " for %i bit usage.\n\n"
-		"Log excerpt:\n"
+		"# log excerpt"
 		/* In the frontends, additional software hints may follow here. */
 
-		, chats, real_msgs, deaddrop_msgs, contacts
-		, context->dbfile? context->dbfile : unset,   dbversion,   context->blobdir? context->blobdir : unset
-
-        , displayname? displayname : unset
-		, is_configured
-		, l_readable_str, l2_readable_str
-
-		, mdns_enabled
-
-		, e2ee_enabled
-		, DC_E2EE_DEFAULT_ENABLED
-		, prv_key_cnt, pub_key_cnt, fingerprint_str
-
 		, DC_VERSION_STR
-		, SQLITE_VERSION, sqlite3_threadsafe()   ,  libetpan_get_version_major(), libetpan_get_version_minor()
+		, SQLITE_VERSION
+		, sqlite3_threadsafe()
+		, libetpan_get_version_major(), libetpan_get_version_minor()
 		, (int)(OPENSSL_VERSION_NUMBER>>28), (int)(OPENSSL_VERSION_NUMBER>>20)&0xFF, (int)(OPENSSL_VERSION_NUMBER>>12)&0xFF, (char)('a'-1+((OPENSSL_VERSION_NUMBER>>4)&0xFF))
 		, sizeof(void*)*8
-
+		, chats
+		, real_msgs
+		, deaddrop_msgs
+		, contacts
+		, context->dbfile? context->dbfile : unset
+		, dbversion
+		, context->blobdir? context->blobdir : unset
+		, displayname? displayname : unset
+		, is_configured
+		, l_readable_str
+		, l2_readable_str
+		, mdns_enabled
+		, e2ee_enabled
+		, DC_E2EE_DEFAULT_ENABLED
+		, prv_key_cnt
+		, pub_key_cnt
+		, fingerprint_str
 		);
 	dc_strbuilder_cat(&ret, temp);
 	free(temp);

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -540,7 +540,7 @@ char* dc_get_info(dc_context_t* context)
 	sqlite3_finalize(stmt);
 
 	if (dc_key_load_self_public(self_public, l2->addr, context->sql)) {
-		fingerprint_str = dc_key_get_formatted_fingerprint(self_public);
+		fingerprint_str = dc_key_get_fingerprint(self_public);
 	}
 	else {
 		fingerprint_str = dc_strdup("<Not yet calculated>");

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -549,11 +549,6 @@ char* dc_get_info(dc_context_t* context)
 	l_readable_str = dc_loginparam_get_readable(l);
 	l2_readable_str = dc_loginparam_get_readable(l2);
 
-	/* create info
-	- some keys are display lower case - these can be changed using the `set`-command
-	- we do not display the password here; in the cli-utility, you can see it using `get mail_pw`
-	- use neutral speach; the Delta Chat Core is not directly related to any front end or end-product
-	- contributors: You're welcome to add your names here */
 	temp = dc_mprintf(
 		"# key=value data\n"
 		"deltachat_core_version=v%s\n"
@@ -582,7 +577,6 @@ char* dc_get_info(dc_context_t* context)
 		"fingerprint=%s\n"
 		"\n"
 		"# log excerpt"
-		/* In the frontends, additional software hints may follow here. */
 
 		, DC_VERSION_STR
 		, SQLITE_VERSION


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-core/issues/348

* use key=value format
* all keys are lower case
* one key/value pair per line
* better naming of some keys

Current format:

```
# key=value data
deltachat_core_version=v0.20.0
sqlite_version=3.22.0
sqlite_thread_safe=1
libetpan_version=1.8
openssl_version=1.0.2n
compile_date=Oct  7 2018, 01:49:02
arch=64
number_of_chats=0
number_of_chat_messages=0
messages_in_contact_requests=0
number_of_contacts=0
database_dir=/tmp/8433c0c3d49135d0250663104b07e2da/db.sqlite
database_version=41
blobdir=/tmp/8433c0c3d49135d0250663104b07e2da/db.sqlite-blobs
display_name=Delta One
is_configured=1
entered_account_settings=delta1@delta.localhost delta1:***:127.0.0.1:3143 delta1:***:127.0.0.1:3025 IMAP_PLAIN SMTP_PLAIN
used_account_settings=delta1@delta.localhost delta1:***:127.0.0.1:3143 delta1:***:127.0.0.1:3025 AUTH_NORMAL IMAP_PLAIN SMTP_PLAIN
mdns_enabled=1
e2ee_enabled=1
e2ee_default_enabled=1
private_key_count=1
public_key_count=0
fingerprint=67BA 1699 E2C2 F0A3 680B
EC45 F447 79F7 41C6 47F6

# log excerpt
01:49:07 First time init: creating tables in "/tmp/8433c0c3d49135d0250663104b07e2da/db.sqlite".
01:49:13 Opened "/tmp/8433c0c3d49135d0250663104b07e2da/db.sqlite".
```