### PR TITLE
slightly rework message sending 

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2116,23 +2116,27 @@ cleanup:
 
 
 /**
- * Send a message of any type to a chat. The given message object is not unref'd
- * by the function but some fields are set up.
+ * Send a message defined by a dc_msg_t object to a chat.
  *
  * Sends the event #DC_EVENT_MSGS_CHANGED on succcess.
  * However, this does not imply, the message really reached the recipient -
  * sending may be delayed eg. due to network problems. However, from your
  * view, you're done with the message. Sooner or later it will find its way.
  *
- * To send a simple text message, you can also use dc_send_text_msg()
- * which is easier to use.
+ * Example:
+ * ~~~
+ * dc_msg_t* msg = dc_msg_new(context, DC_MSG_IMAGE);
+ * dc_msg_set_file(msg, "/file/to/send.jpg", NULL);
+ * dc_send_msg(context, msg);
+ * ~~~
  *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
  * @param chat_id Chat ID to send the message to.
  * @param msg Message object to send to the chat defined by the chat ID.
- *     The function does not take ownership of the object, so you have to
- *     free it using dc_msg_unref() as usual.
+ *     On succcess, msg_id of the object is set up,
+ *     The function does not take ownership of the object,
+ *     so you have to free it using dc_msg_unref() as usual.
  * @return The ID of the message that is about being sent.
  */
 uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
@@ -2250,15 +2254,13 @@ cleanup:
  */
 uint32_t dc_send_text_msg(dc_context_t* context, uint32_t chat_id, const char* text_to_send)
 {
-	dc_msg_t* msg = dc_msg_new_untyped(context);
+	dc_msg_t* msg = dc_msg_new(context, DC_MSG_TEXT);
 	uint32_t  ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || text_to_send==NULL) {
-		dc_log_info(context, 0, "some error");
 		goto cleanup;
 	}
 
-	msg->type = DC_MSG_TEXT;
 	msg->text = dc_strdup(text_to_send);
 
 	ret = dc_send_msg(context, chat_id, msg);
@@ -2269,7 +2271,8 @@ cleanup:
 }
 
 
-/**
+/*
+ * Deprecated, use dc_send_msg() instead.
  * Send an image to a chat.
  *
  * Sends the event #DC_EVENT_MSGS_CHANGED on succcess.
@@ -2313,7 +2316,8 @@ cleanup:
 }
 
 
-/**
+/*
+ * Deprecated, use dc_send_msg() instead.
  * Send a video to a chat.
  *
  * Sends the event #DC_EVENT_MSGS_CHANGED on succcess.
@@ -2362,7 +2366,8 @@ cleanup:
 }
 
 
-/**
+/*
+ * Deprecated, use dc_send_msg() instead.
  * Send a voice message to a chat.  Voice messages are messages just recorded through the device microphone.
  * For sending music or other audio data, use dc_send_audio_msg().
  *
@@ -2403,7 +2408,8 @@ cleanup:
 }
 
 
-/**
+/*
+ * Deprecated, use dc_send_msg() instead.
  * Send an audio file to a chat.  Audio messages are eg. music tracks.
  * For voice messages just recorded though the device microphone, use dc_send_voice_msg().
  *
@@ -2446,7 +2452,8 @@ cleanup:
 }
 
 
-/**
+/*
+ * Deprecated, use dc_send_msg() instead.
  * Send a document to a chat. Use this function to send any document or file to
  * a chat.
  *
@@ -2483,7 +2490,8 @@ cleanup:
 }
 
 
-/**
+/*
+ * Deprecated, use dc_send_msg() instead.
  * Send foreign contact data to a chat.
  *
  * Sends the name and the email address of another contact to a chat.

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -791,7 +791,7 @@ uint32_t dc_create_chat_by_msg_id(dc_context_t* context, uint32_t msg_id)
 {
 	uint32_t   chat_id  = 0;
 	int        send_event = 0;
-	dc_msg_t*  msg = dc_msg_new(context);
+	dc_msg_t*  msg = dc_msg_new_untyped(context);
 	dc_chat_t* chat = dc_chat_new(context);
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC) {
@@ -874,7 +874,7 @@ dc_array_t* dc_get_chat_media(dc_context_t* context, uint32_t chat_id, int msg_t
 uint32_t dc_get_next_media(dc_context_t* context, uint32_t curr_msg_id, int dir)
 {
 	uint32_t    ret_msg_id = 0;
-	dc_msg_t*   msg = dc_msg_new(context);
+	dc_msg_t*   msg = dc_msg_new_untyped(context);
 	dc_array_t* list = NULL;
 	int         i = 0;
 	int         cnt = 0;
@@ -1614,7 +1614,7 @@ int dc_set_chat_name(dc_context_t* context, uint32_t chat_id, const char* new_na
 	/* the function only sets the names of group chats; normal chats get their names from the contacts */
 	int        success = 0;
 	dc_chat_t* chat = dc_chat_new(context);
-	dc_msg_t*  msg = dc_msg_new(context);
+	dc_msg_t*  msg = dc_msg_new_untyped(context);
 	char*      q3 = NULL;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || new_name==NULL || new_name[0]==0 || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
@@ -1683,7 +1683,7 @@ int dc_set_chat_profile_image(dc_context_t* context, uint32_t chat_id, const cha
 {
 	int        success = 0;
 	dc_chat_t* chat = dc_chat_new(context);
-	dc_msg_t*  msg = dc_msg_new(context);
+	dc_msg_t*  msg = dc_msg_new_untyped(context);
 	char*      new_image_rel = NULL;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
@@ -1786,7 +1786,7 @@ int dc_add_contact_to_chat_ex(dc_context_t* context, uint32_t chat_id, uint32_t 
 	int              success = 0;
 	dc_contact_t*    contact = dc_get_contact(context, contact_id);
 	dc_chat_t*       chat = dc_chat_new(context);
-	dc_msg_t*        msg = dc_msg_new(context);
+	dc_msg_t*        msg = dc_msg_new_untyped(context);
 	char*            self_addr = NULL;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || contact==NULL || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
@@ -1903,7 +1903,7 @@ int dc_remove_contact_from_chat(dc_context_t* context, uint32_t chat_id, uint32_
 	int           success = 0;
 	dc_contact_t* contact = dc_get_contact(context, contact_id);
 	dc_chat_t*    chat = dc_chat_new(context);
-	dc_msg_t*     msg = dc_msg_new(context);
+	dc_msg_t*     msg = dc_msg_new_untyped(context);
 	char*         q3 = NULL;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || (contact_id<=DC_CONTACT_ID_LAST_SPECIAL && contact_id!=DC_CONTACT_ID_SELF)) {
@@ -2250,7 +2250,7 @@ cleanup:
  */
 uint32_t dc_send_text_msg(dc_context_t* context, uint32_t chat_id, const char* text_to_send)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	uint32_t  ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || text_to_send==NULL) {
@@ -2290,7 +2290,7 @@ cleanup:
  */
 uint32_t dc_send_image_msg(dc_context_t* context, uint32_t chat_id, const char* file, const char* filemime, int width, int height)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	uint32_t  ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || file==NULL) {
@@ -2335,7 +2335,7 @@ cleanup:
  */
 uint32_t dc_send_video_msg(dc_context_t* context, uint32_t chat_id, const char* file, const char* filemime, int width, int height, int duration)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	uint32_t  ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || file==NULL) {
@@ -2381,7 +2381,7 @@ cleanup:
  */
 uint32_t dc_send_voice_msg(dc_context_t* context, uint32_t chat_id, const char* file, const char* filemime, int duration)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	uint32_t  ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || file==NULL) {
@@ -2424,7 +2424,7 @@ cleanup:
  */
 uint32_t dc_send_audio_msg(dc_context_t* context, uint32_t chat_id, const char* file, const char* filemime, int duration, const char* author, const char* trackname)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	uint32_t ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || file==NULL) {
@@ -2464,7 +2464,7 @@ cleanup:
  */
 uint32_t dc_send_file_msg(dc_context_t* context, uint32_t chat_id, const char* file, const char* filemime)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	uint32_t  ret = 0;
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL || file==NULL) {
@@ -2506,7 +2506,7 @@ cleanup:
 uint32_t dc_send_vcard_msg(dc_context_t* context, uint32_t chat_id, uint32_t contact_id)
 {
 	uint32_t      ret = 0;
-	dc_msg_t*     msg = dc_msg_new(context);
+	dc_msg_t*     msg = dc_msg_new_untyped(context);
 	dc_contact_t* contact = NULL;
 	char*         text_to_send = NULL;
 
@@ -2584,7 +2584,7 @@ cleanup:
  */
 void dc_forward_msgs(dc_context_t* context, const uint32_t* msg_ids, int msg_cnt, uint32_t chat_id)
 {
-	dc_msg_t*      msg = dc_msg_new(context);
+	dc_msg_t*      msg = dc_msg_new_untyped(context);
 	dc_chat_t*     chat = dc_chat_new(context);
 	dc_contact_t*  contact = dc_contact_new(context);
 	int            transaction_pending = 0;

--- a/src/dc_chatlist.c
+++ b/src/dc_chatlist.c
@@ -206,7 +206,7 @@ dc_lot_t* dc_chatlist_get_summary(const dc_chatlist_t* chatlist, size_t index, d
 
 	if (lastmsg_id)
 	{
-		lastmsg = dc_msg_new(chatlist->context);
+		lastmsg = dc_msg_new_untyped(chatlist->context);
 		dc_msg_load_from_db(lastmsg, chatlist->context, lastmsg_id);
 
 		if (lastmsg->from_id!=DC_CONTACT_ID_SELF  &&  DC_CHAT_TYPE_IS_MULTI(chat->type))

--- a/src/dc_imex.c
+++ b/src/dc_imex.c
@@ -499,7 +499,7 @@ char* dc_initiate_key_transfer(dc_context_t* context)
 		goto cleanup;
 	}
 
-	msg = dc_msg_new(context);
+	msg = dc_msg_new_untyped(context);
 	msg->type = DC_MSG_FILE;
 	dc_param_set    (msg->param, DC_PARAM_FILE,              setup_file_name);
 	dc_param_set    (msg->param, DC_PARAM_MIMETYPE,          "application/autocrypt-setup");

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -116,7 +116,7 @@ cleanup:
 static void dc_job_do_DC_JOB_DELETE_MSG_ON_IMAP(dc_context_t* context, dc_job_t* job)
 {
 	int           delete_from_server = 1;
-	dc_msg_t*     msg = dc_msg_new(context);
+	dc_msg_t*     msg = dc_msg_new_untyped(context);
 	sqlite3_stmt* stmt = NULL;
 
 	if (!dc_msg_load_from_db(msg, context, job->foreign_id)
@@ -212,7 +212,7 @@ cleanup:
 
 static void dc_job_do_DC_JOB_MARKSEEN_MSG_ON_IMAP(dc_context_t* context, dc_job_t* job)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 	char*     new_server_folder = NULL;
 	uint32_t  new_server_uid = 0;
 	int       in_ms_flags = 0;

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -138,7 +138,7 @@ int dc_mimefactory_load_msg(dc_mimefactory_t* factory, uint32_t msg_id)
 
 	factory->recipients_names = clist_new();
 	factory->recipients_addr  = clist_new();
-	factory->msg              = dc_msg_new(context);
+	factory->msg              = dc_msg_new_untyped(context);
 	factory->chat             = dc_chat_new(context);
 
 		if (dc_msg_load_from_db(factory->msg, context, msg_id)
@@ -274,7 +274,7 @@ int dc_mimefactory_load_mdn(dc_mimefactory_t* factory, uint32_t msg_id)
 
 	factory->recipients_names = clist_new();
 	factory->recipients_addr  = clist_new();
-	factory->msg              = dc_msg_new(factory->context);
+	factory->msg              = dc_msg_new_untyped(factory->context);
 
 	if (!dc_sqlite3_get_config_int(factory->context->sql, "mdns_enabled", DC_MDNS_DEFAULT_ENABLED)) {
 		goto cleanup; /* MDNs not enabled - check this is late, in the job. the use may have changed its choice while offline ... */
@@ -672,7 +672,7 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 
 		if (grpimage)
 		{
-			dc_msg_t* meta = dc_msg_new(factory->context);
+			dc_msg_t* meta = dc_msg_new_untyped(factory->context);
 			meta->type = DC_MSG_IMAGE;
 			dc_param_set(meta->param, DC_PARAM_FILE, grpimage);
 			char* filename_as_sent = NULL;

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1094,25 +1094,6 @@ void dc_msg_save_param_to_disk(dc_msg_t* msg)
 
 
 /**
- * Set the type of a message object.
- * The function does not check of the type is valid and the function does not alter any information in the database;
- * both may be done by dc_send_msg() later.
- *
- * @memberof dc_msg_t
- * @param msg The message object.
- * @param type The type to set, one of the @ref DC_MSG constants
- * @return None.
- */
-void dc_msg_set_type(dc_msg_t* msg, int type)
-{
-	if (msg==NULL || msg->magic!=DC_MSG_MAGIC) {
-		return;
-	}
-	msg->type = type;
-}
-
-
-/**
  * Set the text of a message object.
  * This does not alter any information in the database; this may be done by dc_send_msg() later.
  *

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -38,11 +38,11 @@
  *
  * @memberof dc_msg_t
  * @param context The context that should be stored in the message object.
- * @param view_type The type to the message object to create,
+ * @param viewtype The type to the message object to create,
  *     one of the @ref DC_MSG constants.
  * @return The created message object.
  */
-dc_msg_t* dc_msg_new(dc_context_t* context, int view_type)
+dc_msg_t* dc_msg_new(dc_context_t* context, int viewtype)
 {
 	dc_msg_t* msg = NULL;
 
@@ -52,7 +52,7 @@ dc_msg_t* dc_msg_new(dc_context_t* context, int view_type)
 
 	msg->context   = context;
 	msg->magic     = DC_MSG_MAGIC;
-	msg->type      = view_type;
+	msg->type      = viewtype;
 	msg->state     = DC_STATE_UNDEFINED;
 	msg->param     = dc_param_new();
 
@@ -179,7 +179,7 @@ uint32_t dc_msg_get_chat_id(const dc_msg_t* msg)
  * @param msg The message object.
  * @return One of the @ref DC_MSG constants.
  */
-int dc_msg_get_type(const dc_msg_t* msg)
+int dc_msg_get_viewtype(const dc_msg_t* msg)
 {
 	if (msg==NULL || msg->magic!=DC_MSG_MAGIC) {
 		return DC_MSG_UNDEFINED;
@@ -745,7 +745,7 @@ int dc_msg_is_info(const dc_msg_t* msg)
  * @memberof dc_msg_t
  * @param msg The message object.
  * @return 1=message is a setup message, 0=no setup message.
- *     For setup messages, dc_msg_get_type() returns DC_MSG_FILE.
+ *     For setup messages, dc_msg_get_viewtype() returns DC_MSG_FILE.
  */
 int dc_msg_is_setupmessage(const dc_msg_t* msg)
 {

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -38,9 +38,11 @@
  *
  * @memberof dc_msg_t
  * @param context The context that should be stored in the message object.
+ * @param view_type The type to the message object to create,
+ *     one of the @ref DC_MSG constants.
  * @return The created message object.
  */
-dc_msg_t* dc_msg_new(dc_context_t* context)
+dc_msg_t* dc_msg_new(dc_context_t* context, int view_type)
 {
 	dc_msg_t* msg = NULL;
 
@@ -50,11 +52,17 @@ dc_msg_t* dc_msg_new(dc_context_t* context)
 
 	msg->context   = context;
 	msg->magic     = DC_MSG_MAGIC;
-	msg->type      = DC_MSG_UNDEFINED;
+	msg->type      = view_type;
 	msg->state     = DC_STATE_UNDEFINED;
 	msg->param     = dc_param_new();
 
 	return msg;
+}
+
+
+dc_msg_t* dc_msg_new_untyped(dc_context_t* context)
+{
+	return dc_msg_new(context, DC_MSG_UNDEFINED);
 }
 
 
@@ -1287,7 +1295,7 @@ void dc_update_msg_state(dc_context_t* context, uint32_t msg_id, int state)
  */
 void dc_set_msg_failed(dc_context_t* context, uint32_t msg_id, const char* error)
 {
-	dc_msg_t*     msg = dc_msg_new(context);
+	dc_msg_t*     msg = dc_msg_new_untyped(context);
 	sqlite3_stmt* stmt = NULL;
 
 	if (!dc_msg_load_from_db(msg, context, msg_id)) {
@@ -1450,7 +1458,7 @@ void dc_update_server_uid(dc_context_t* context, const char* rfc724_mid, const c
 dc_msg_t* dc_get_msg(dc_context_t* context, uint32_t msg_id)
 {
 	int success = 0;
-	dc_msg_t* obj = dc_msg_new(context);
+	dc_msg_t* obj = dc_msg_new_untyped(context);
 
 	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC) {
 		goto cleanup;
@@ -1488,7 +1496,7 @@ cleanup:
 char* dc_get_msg_info(dc_context_t* context, uint32_t msg_id)
 {
 	sqlite3_stmt*   stmt = NULL;
-	dc_msg_t*       msg = dc_msg_new(context);
+	dc_msg_t*       msg = dc_msg_new_untyped(context);
 	dc_contact_t*   contact_from = dc_contact_new(context);
 	char*           rawtxt = NULL;
 	char*           p = NULL;

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -65,7 +65,7 @@ struct _dc_msg
 	uint32_t        chat_id;
 
 
-	int             type;                   /**< Message type. It is recommended to use dc_msg_set_type() and dc_msg_get_type() to access this field. */
+	int             type;                   /**< Message view type. */
 
 	int             state;                  /**< Message state. It is recommended to use dc_msg_get_state() to access this field. */
 

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -88,6 +88,7 @@ struct _dc_msg
 };
 
 
+dc_msg_t*       dc_msg_new_untyped                    (dc_context_t*);
 int             dc_msg_load_from_db                   (dc_msg_t*, dc_context_t*, uint32_t id);
 int             dc_msg_is_increation                  (const dc_msg_t*);
 char*           dc_msg_get_summarytext_by_raw         (int type, const char* text, dc_param_t*, int approx_bytes, dc_context_t*); /* the returned value must be free()'d */

--- a/src/dc_securejoin.c
+++ b/src/dc_securejoin.c
@@ -226,7 +226,7 @@ static const char* lookup_field(dc_mimeparser_t* mimeparser, const char* key)
 
 static void send_handshake_msg(dc_context_t* context, uint32_t contact_chat_id, const char* step, const char* param2, const char* fingerprint, const char* grpid)
 {
-	dc_msg_t* msg = dc_msg_new(context);
+	dc_msg_t* msg = dc_msg_new_untyped(context);
 
 	msg->type = DC_MSG_TEXT;
 	msg->text = dc_mprintf("Secure-Join: %s", step);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -489,7 +489,7 @@ typedef struct _dc_msg dc_msg_t;
 #define         DC_MAX_GET_INFO_LEN          100000 // approx. max. lenght returned by dc_get_msg_info()
 
 
-dc_msg_t*       dc_msg_new                   (dc_context_t*);
+dc_msg_t*       dc_msg_new                   (dc_context_t*, int view_type);
 void            dc_msg_unref                 (dc_msg_t*);
 void            dc_msg_empty                 (dc_msg_t*);
 uint32_t        dc_msg_get_id                (const dc_msg_t*);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -517,7 +517,6 @@ int             dc_msg_is_info               (const dc_msg_t*);
 int             dc_msg_is_increation         (const dc_msg_t*);
 int             dc_msg_is_setupmessage       (const dc_msg_t*);
 char*           dc_msg_get_setupcodebegin    (const dc_msg_t*);
-void            dc_msg_set_type              (dc_msg_t*, int type);
 void            dc_msg_set_text              (dc_msg_t*, const char* text);
 void            dc_msg_set_file              (dc_msg_t*, const char* file, const char* filemime);
 void            dc_msg_set_dimension         (dc_msg_t*, int width, int height);
@@ -589,13 +588,13 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 /**
  * @defgroup DC_MSG DC_MSG
  *
- * With the constants the type of a message is defined.
+ * With these constants the type of a message is defined.
  * From the view of the library, all types are all primary types of the same level,
  * so the library does not regard eg. #DC_MSG_GIF as a subtype for #DC_MSG_IMAGE and
  * it's up to the UI to decide whether a GIF is shown eg. in an IMAGE or in a VIDEO
  * container.
  *
- * If you want to define the type of a dc_msg_t object for sending, use dc_msg_set_type().
+ * If you want to define the type of a dc_msg_t object for sending, use dc_msg_new().
  *
  * To get the types of dc_msg_t objects received, use dc_msg_get_type().
  *

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -489,13 +489,13 @@ typedef struct _dc_msg dc_msg_t;
 #define         DC_MAX_GET_INFO_LEN          100000 // approx. max. lenght returned by dc_get_msg_info()
 
 
-dc_msg_t*       dc_msg_new                   (dc_context_t*, int view_type);
+dc_msg_t*       dc_msg_new                   (dc_context_t*, int viewtype);
 void            dc_msg_unref                 (dc_msg_t*);
 void            dc_msg_empty                 (dc_msg_t*);
 uint32_t        dc_msg_get_id                (const dc_msg_t*);
 uint32_t        dc_msg_get_from_id           (const dc_msg_t*);
 uint32_t        dc_msg_get_chat_id           (const dc_msg_t*);
-int             dc_msg_get_type              (const dc_msg_t*);
+int             dc_msg_get_viewtype          (const dc_msg_t*);
 int             dc_msg_get_state             (const dc_msg_t*);
 time_t          dc_msg_get_timestamp         (const dc_msg_t*);
 char*           dc_msg_get_text              (const dc_msg_t*);
@@ -596,7 +596,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  *
  * If you want to define the type of a dc_msg_t object for sending, use dc_msg_new().
  *
- * To get the types of dc_msg_t objects received, use dc_msg_get_type().
+ * To get the types of dc_msg_t objects received, use dc_msg_get_viewtype().
  *
  * @addtogroup DC_MSG
  * @{

--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -186,7 +186,7 @@ extern "C" {
 #define mrmsg_get_id                        dc_msg_get_id
 #define mrmsg_get_from_id                   dc_msg_get_from_id
 #define mrmsg_get_chat_id                   dc_msg_get_chat_id
-#define mrmsg_get_type                      dc_msg_get_type
+#define mrmsg_get_type                      dc_msg_get_viewtype
 #define mrmsg_get_state                     dc_msg_get_state
 #define mrmsg_get_timestamp                 dc_msg_get_timestamp
 #define mrmsg_get_text                      dc_msg_get_text


### PR DESCRIPTION
- force dc_msg_new() to take the view type
- remove dc_msg_set_type()
- dc_msg_get_type() renamed to dc_msg_get_viewtype() (not: view_type)
- mark dc_send_X_msg() as being deprecated (would like to remove them soon)
