### PR TITLE
remove DC_MSG_UNDEFINED from API

### DIFF
--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -672,7 +672,7 @@ static int mailmime_get_mime_type(struct mailmime* mime, int* msg_type)
 
 	struct mailmime_content* c = mime->mm_content_type;
 	int dummy = 0; if (msg_type==NULL) { msg_type = &dummy; }
-	*msg_type = DC_MSG_UNDEFINED;
+	*msg_type = 0;
 
 	if (c==NULL || c->ct_type==NULL) {
 		return 0;
@@ -786,7 +786,7 @@ static dc_mimepart_t* dc_mimepart_new(void)
 		exit(33);
 	}
 
-	mimepart->type    = DC_MSG_UNDEFINED;
+	mimepart->type    = 0;
 	mimepart->param   = dc_param_new();
 
 	return mimepart;

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -62,7 +62,7 @@ dc_msg_t* dc_msg_new(dc_context_t* context, int viewtype)
 
 dc_msg_t* dc_msg_new_untyped(dc_context_t* context)
 {
-	return dc_msg_new(context, DC_MSG_UNDEFINED);
+	return dc_msg_new(context, 0);
 }
 
 
@@ -120,7 +120,8 @@ void dc_msg_empty(dc_msg_t* msg)
  *
  * @memberof dc_msg_t
  * @param msg The message object.
- * @return The ID of the message, 0 on errors.
+ * @return The ID of the message.
+ *     0 if the given message object is invalid.
  */
 uint32_t dc_msg_get_id(const dc_msg_t* msg)
 {
@@ -179,11 +180,12 @@ uint32_t dc_msg_get_chat_id(const dc_msg_t* msg)
  * @memberof dc_msg_t
  * @param msg The message object.
  * @return One of the @ref DC_MSG constants.
+ *     0 if the given message object is invalid.
  */
 int dc_msg_get_viewtype(const dc_msg_t* msg)
 {
 	if (msg==NULL || msg->magic!=DC_MSG_MAGIC) {
-		return DC_MSG_UNDEFINED;
+		return 0;
 	}
 	return msg->type;
 }
@@ -908,7 +910,7 @@ void dc_msg_guess_msgtype_from_suffix(const char* pathNfilename, int* ret_msgtyp
 	if (ret_msgtype==NULL) { ret_msgtype = &dummy_msgtype; }
 	if (ret_mime==NULL)    { ret_mime = &dummy_buf; }
 
-	*ret_msgtype = DC_MSG_UNDEFINED;
+	*ret_msgtype = 0;
 	*ret_mime = NULL;
 
 	suffix = dc_get_filesuffix_lc(pathNfilename);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -602,11 +602,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  * @{
  */
 
-/**
- * Type undefined.
- */
-#define DC_MSG_UNDEFINED  0
-
 
 /**
  * Text message.

--- a/src/mrmailbox.h
+++ b/src/mrmailbox.h
@@ -164,7 +164,7 @@ extern "C" {
 #define MR_MSG_ID_MARKER1                   DC_MSG_ID_MARKER1
 #define MR_MSG_ID_DAYMARKER                 DC_MSG_ID_DAYMARKER
 #define MR_MSG_ID_LAST_SPECIAL              DC_MSG_ID_LAST_SPECIAL
-#define MR_MSG_UNDEFINED                    DC_MSG_UNDEFINED
+#define MR_MSG_UNDEFINED                    0
 #define MR_MSG_TEXT                         DC_MSG_TEXT
 #define MR_MSG_IMAGE                        DC_MSG_IMAGE
 #define MR_MSG_GIF                          DC_MSG_GIF


### PR DESCRIPTION
just remove the DC_MSG_UNDEFINED viewtype from the API.

internally, 0=undefined is still used, but it is no longer valid for input from the API and is no longer returned.