### PR TITLE
remove default-parameter from dc_get_config()

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -487,7 +487,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 	else if (!s_is_auth)
 	{
 		if (strcmp(cmd, "auth")==0) {
-			char* is_pw = dc_get_config(context, "mail_pw", "");
+			char* is_pw = dc_get_config(context, "mail_pw");
 			if (strcmp(arg1, is_pw)==0) {
 				s_is_auth = 1;
 				ret = COMMAND_SUCCEEDED;
@@ -646,14 +646,9 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 	else if (strcmp(cmd, "get")==0)
 	{
 		if (arg1) {
-			char* val = dc_get_config(context, arg1, "<unset>");
-			if (val) {
-				ret = dc_mprintf("%s=%s", arg1, val);
-				free(val);
-			}
-			else {
-				ret = COMMAND_FAILED;
-			}
+			char* val = dc_get_config(context, arg1);
+			ret = dc_mprintf("%s=%s", arg1, val);
+			free(val);
 		}
 		else {
 			ret = dc_strdup("ERROR: Argument <key> missing.");

--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -360,6 +360,9 @@ void stress_functions(dc_context_t* context)
 	 **************************************************************************/
 
 	{
+		assert( atol("")==0 ); /* we rely on this eg. in dc_sqlite3_get_config() */
+		assert( atoi("")==0 );
+
 		assert( !dc_may_be_valid_addr(NULL) );
 		assert( !dc_may_be_valid_addr("") );
 		assert(  dc_may_be_valid_addr("user@domain.tld") );

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -76,9 +76,8 @@ class Account(object):
         if name != "sys.config_keys":
             self._check_config_key(name)
         name = name.encode("utf8")
-        res = lib.dc_get_config(self._dc_context, name, ffi.NULL)
-        if res == ffi.NULL:
-            raise KeyError("config value not found for: {!r}".format(name))
+        res = lib.dc_get_config(self._dc_context, name)
+        assert res != ffi.NULL, "config value not found for: {!r}".format(name)
         return from_dc_charpointer(res)
 
     def configure(self, **kwargs):

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -230,7 +230,7 @@ int             dc_is_open                   (const dc_context_t*);
 char*           dc_get_blobdir               (const dc_context_t*);
 
 int             dc_set_config                (dc_context_t*, const char* key, const char* value);
-char*           dc_get_config                (dc_context_t*, const char* key, const char* def);
+char*           dc_get_config                (dc_context_t*, const char* key);
 char*           dc_get_info                  (dc_context_t*);
 char*           dc_get_version_str           (void);
 void            dc_openssl_init_not_required (void);


### PR DESCRIPTION
dc_get_config() return the appropriate default parameter automatically if no value was set before.

NULL is never returned.

closes #367 

EDIT: of course, travis does not built because of the changed function signature :)