### PR TITLE
Build the lib in a few supported ways

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ language: c
 env:
   - DEPLOY_USER=delta DEPLOY_SERVER="py.delta.chat"
 
+  matrix:
+    - MESONARGS=""
+    - MESONARGS="-Dmonolith=true"
+    - MESONARGS="--default-library=static"
+    - MESONARGS="--wrap-mode=forcefallback --default-library=static"
+
 addons:
   apt:
     sources:
@@ -35,34 +41,21 @@ install:
 
 script:
   - doxygen --version
-  - mkdir -p builddir && cd builddir && meson && ninja -v && sudo ninja install
   - mkdir -p builddir && pushd builddir
-  - meson && ninja -v && sudo ninja install
-  - export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+  - meson $MESONARGS && ninja -v && sudo ninja install
   - export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
   - sudo ldconfig -v
-  - sudo ldconfig -v
-  - cd ../docs
   - popd && pushd docs
   - doxygen
   - doxygen
-  - cd ../python
   - popd && pushd python
   - virtualenv -p /usr/bin/python3.5 venv
-  - virtualenv -p /usr/bin/python3.5 venv
-  - source venv/bin/activate
   - source venv/bin/activate
   - pip install tox
-  - pip install tox
-  - ldd /usr/local/lib/x86_64-linux-gnu/libdeltachat.so
   - ldd /usr/local/lib/x86_64-linux-gnu/libdeltachat.so
   - tox
-  - tox -e doc
+  - test "$MESONARGS" == "" && tox -e doc
   - popd
-  # Ensure a few ways of building delta-core keep working
-  - meson setup build-monolith -Dmonolith=true && ninja -C build-monolith
-  - meson setup build-fallbacks --wrap-mode=forcefallback --default-library=static && ninja -C build-fallbacks
-  - meson setup build-static --default-library=static && ninja -C build-static
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,17 +36,33 @@ install:
 script:
   - doxygen --version
   - mkdir -p builddir && cd builddir && meson && ninja -v && sudo ninja install
+  - mkdir -p builddir && pushd builddir
+  - meson && ninja -v && sudo ninja install
+  - export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
   - export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
   - sudo ldconfig -v
+  - sudo ldconfig -v
   - cd ../docs
+  - popd && pushd docs
+  - doxygen
   - doxygen
   - cd ../python
+  - popd && pushd python
+  - virtualenv -p /usr/bin/python3.5 venv
   - virtualenv -p /usr/bin/python3.5 venv
   - source venv/bin/activate
+  - source venv/bin/activate
+  - pip install tox
   - pip install tox
   - ldd /usr/local/lib/x86_64-linux-gnu/libdeltachat.so
-  - tox 
-  - tox -e doc 
+  - ldd /usr/local/lib/x86_64-linux-gnu/libdeltachat.so
+  - tox
+  - tox -e doc
+  - popd
+  # Ensure a few ways of building delta-core keep working
+  - meson setup build-monolith -Dmonolith=true && ninja -C build-monolith
+  - meson setup build-fallbacks --wrap-mode=forcefallback --default-library=static && ninja -C build-fallbacks
+  - meson setup build-static --default-library=static && ninja -C build-static
 
 deploy:
   provider: script


### PR DESCRIPTION
This should prevent changes to the build system accidentally breaking some supported ways we want to build.

I'm no travis expert though, just tagging this onto the back seems somewhat wrong.  It would be nicer if they where sub-jobs or something like that - if that even exists.