### PR TITLE
speed up messages sending

### DIFF
--- a/libs/netpgp/src/openssl_crypto.c
+++ b/libs/netpgp/src/openssl_crypto.c
@@ -527,10 +527,14 @@ pgp_rsa_private_encrypt(uint8_t *out,
 
 
 	/* debug */
+	/* as the check takes ~800 ms, we disable it for now.
+	   (the key is already checked in deltachat-core-land
+	   and RSA_private_encrypt() will return an error on problems)
 	if (RSA_check_key(orsa) != 1) {
 		(void) fprintf(stderr, "RSA_check_key is not set\n");
 		return 0;
 	}
+	*/
 	/* end debug */
 
 	n = RSA_private_encrypt((int)length, in, out, orsa, RSA_NO_PADDING);


### PR DESCRIPTION
while figuring out the slowness of openssl, see #376, i came across an probably unused debug routine that takes up ~ 500 ms on each message sending, it's in the message signing-part (not encryption as the function name may suggest).

as the message cannot go to smtp before it is signed and encrypted, the whole sending process is delayed by just this time.

moreover, this pr adds an info line to the log that shows the time needed for signing and encryption. for me unexpectedly, the encryption is more than 50 times faster than the signing.

(all times refer to my nexus 4 testing device and to a short text message of a few words)

