### PR TITLE
allow text added to images/files/etc.

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -449,7 +449,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"groupimage [<file>]\n"
 				"chatinfo\n"
 				"send <text>\n"
-				"sendimage <file>\n"
+				"sendimage <file> [<text>]\n"
 				"sendfile <file>\n"
 				"draft [<text>]\n"
 				"listmedia\n"
@@ -912,35 +912,20 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 			ret = dc_strdup("No chat selected.");
 		}
 	}
-	else if (strcmp(cmd, "sendimage")==0)
+	else if (strcmp(cmd, "sendimage")==0 || strcmp(cmd, "sendfile")==0)
 	{
 		if (sel_chat) {
 			if (arg1 && arg1[0]) {
-				if (dc_send_image_msg(context, dc_chat_get_id(sel_chat), arg1, NULL, 0, 0)) {
-					ret = dc_strdup("Image sent.");
-				}
-				else {
-					ret = dc_strdup("ERROR: Sending image failed.");
-				}
-			}
-			else {
-				ret = dc_strdup("ERROR: No image given.");
-			}
-		}
-		else {
-			ret = dc_strdup("No chat selected.");
-		}
-	}
-	else if (strcmp(cmd, "sendfile")==0)
-	{
-		if (sel_chat) {
-			if (arg1 && arg1[0]) {
-				if (dc_send_file_msg(context, dc_chat_get_id(sel_chat), arg1, NULL)) {
-					ret = dc_strdup("File sent.");
-				}
-				else {
-					ret = dc_strdup("ERROR: Sending file failed.");
-				}
+				char* arg2 = strchr(arg1, ' ');
+				if (arg2) { *arg2 = 0; arg2++; }
+
+				dc_msg_t* msg = dc_msg_new(context,
+					strcmp(cmd, "sendimage")==0? DC_MSG_IMAGE : DC_MSG_FILE);
+				dc_msg_set_file(msg, arg1, NULL);
+				dc_msg_set_text(msg, arg2);
+				dc_send_msg(context, dc_chat_get_id(sel_chat), msg);
+				dc_msg_unref(msg);
+				ret = COMMAND_SUCCEEDED;
 			}
 			else {
 				ret = dc_strdup("ERROR: No file given.");

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2185,23 +2185,6 @@ uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 			}
 
 			dc_log_info(context, 0, "Attaching \"%s\" for message type #%i.", pathNfilename, (int)msg->type);
-
-			if (msg->text) { free(msg->text); }
-			if (msg->type==DC_MSG_AUDIO) {
-				char* filename = dc_get_filename(pathNfilename);
-				char* author = dc_param_get(msg->param, DC_PARAM_AUTHORNAME, "");
-				char* title = dc_param_get(msg->param, DC_PARAM_TRACKNAME, "");
-				msg->text = dc_mprintf("%s %s %s", filename, author, title); /* for outgoing messages, also add the mediainfo. For incoming messages, this is not needed as the filename is build from these information */
-				free(filename);
-				free(author);
-				free(title);
-			}
-			else if (DC_MSG_MAKE_FILENAME_SEARCHABLE(msg->type)) {
-				msg->text = dc_get_filename(pathNfilename);
-			}
-			else if (DC_MSG_MAKE_SUFFIX_SEARCHABLE(msg->type)) {
-				msg->text = dc_get_filesuffix_lc(pathNfilename);
-			}
 		}
 		else
 		{
@@ -2244,7 +2227,7 @@ cleanup:
  * sending may be delayed eg. due to network problems. However, from your
  * view, you're done with the message. Sooner or later it will find its way.
  *
- * See also dc_send_image_msg().
+ * See also dc_send_msg().
  *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -705,11 +705,11 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 		}
 
 		const char* final_text = NULL;
-		if (msg->type==DC_MSG_TEXT && msg->text && msg->text[0]) { /* `text` may also contain data otherwise, eg. the filename of attachments */
-			final_text = msg->text;
-		}
-		else if (placeholdertext) {
+		if (placeholdertext) {
 			final_text = placeholdertext;
+		}
+		else if (msg->text && msg->text[0]) {
+			final_text = msg->text;
 		}
 
 		char* footer = factory->selfstatus;

--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -965,12 +965,6 @@ static void do_add_single_file_part(dc_mimeparser_t* parser, int msg_type, int m
 	part->int_mimetype = mime_type;
 	part->bytes = decoded_data_bytes;
 	dc_param_set(part->param, DC_PARAM_FILE, pathNfilename);
-	if (DC_MSG_MAKE_FILENAME_SEARCHABLE(msg_type)) {
-		part->msg = dc_get_filename(pathNfilename);
-	}
-	else if (DC_MSG_MAKE_SUFFIX_SEARCHABLE(msg_type)) {
-		part->msg = dc_get_filesuffix_lc(pathNfilename);
-	}
 
 	if (mime_type==DC_MIMETYPE_IMAGE) {
 		uint32_t w = 0, h = 0;

--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -799,15 +799,11 @@ static void dc_mimepart_unref(dc_mimepart_t* mimepart)
 		return;
 	}
 
-	if (mimepart->msg) {
-		free(mimepart->msg);
-		mimepart->msg = NULL;
-	}
+	free(mimepart->msg);
+	mimepart->msg = NULL;
 
-	if (mimepart->msg_raw) {
-		free(mimepart->msg_raw);
-		mimepart->msg_raw = NULL;
-	}
+	free(mimepart->msg_raw);
+	mimepart->msg_raw = NULL;
 
 	dc_param_unref(mimepart->param);
 	free(mimepart);
@@ -863,8 +859,15 @@ void dc_mimeparser_unref(dc_mimeparser_t* mimeparser)
 	}
 
 	dc_mimeparser_empty(mimeparser);
-	if (mimeparser->parts)   { carray_free(mimeparser->parts); }
-	if (mimeparser->reports) { carray_free(mimeparser->reports); }
+
+	if (mimeparser->parts) {
+		carray_free(mimeparser->parts);
+	}
+
+	if (mimeparser->reports) {
+		carray_free(mimeparser->reports);
+	}
+
 	free(mimeparser->e2ee_helper);
 	free(mimeparser);
 }
@@ -1482,10 +1485,6 @@ void dc_mimeparser_parse(dc_mimeparser_t* mimeparser, const char* body_not_termi
 
 	/* recursively check, whats parsed, this also sets up header_old */
 	dc_mimeparser_parse_mime_recursive(mimeparser, mimeparser->mimeroot);
-
-	// TOCHECK: text parts may be moved to the beginning of the list - either here or in do_add_single_part()
-	//       usecase: eg. the Buchungsbestätigungen of Deutsch Bahn have the PDF before the explaining text.
-	//       may also be handy for extracting binaries from uuencoded text and just add the rest text after the binaries.
 
 	/* setup header */
 	hash_header(&mimeparser->header, mimeparser->header_root, mimeparser->context);

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -97,8 +97,6 @@ void            dc_msg_guess_msgtype_from_suffix      (const char* pathNfilename
 void            dc_msg_get_authorNtitle_from_filename (const char* pathNfilename, char** ret_author, char** ret_title);
 
 #define DC_MSG_NEEDS_ATTACHMENT(a)         ((a)==DC_MSG_IMAGE || (a)==DC_MSG_GIF || (a)==DC_MSG_AUDIO || (a)==DC_MSG_VOICE || (a)==DC_MSG_VIDEO || (a)==DC_MSG_FILE)
-#define DC_MSG_MAKE_FILENAME_SEARCHABLE(a) ((a)==DC_MSG_AUDIO || (a)==DC_MSG_FILE || (a)==DC_MSG_VIDEO) /* add filename.ext (without path) to text? this is needed for the fulltext search. The extension is useful to get all PDF, all MP3 etc. */
-#define DC_MSG_MAKE_SUFFIX_SEARCHABLE(a)   ((a)==DC_MSG_IMAGE || (a)==DC_MSG_GIF || (a)==DC_MSG_VOICE)
 
 
 /* as we do not cut inside words, this results in about 32-42 characters.

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -234,6 +234,7 @@ char*           dc_get_config                (dc_context_t*, const char* key);
 char*           dc_get_info                  (dc_context_t*);
 char*           dc_get_version_str           (void);
 void            dc_openssl_init_not_required (void);
+void            dc_no_compound_msgs          (void); // deprecated
 
 
 // connect


### PR DESCRIPTION
this pr makes deletachat-core able to add text to images/file/music/voice messages.

the text is added to the message object as usual using `dc_msg_set_text()`.

receiving such messages is also straight forward: _any_ message type can now contain text that can be retrieved using `dc_msg_get_text()`. 

this change makes it much easier to add some lines of text to a file.
the added text also appears smart together with the image/file in non-delta-muas. 

to allow the old telegram-ui to show these new compound messages without changes, i've added the function dc_no_compound_msgs() that let the core generate single messages for the description, however, this function is not documented and will be removed soon. all UIs should just be able to show the text attached to files.

btw. i do not think that more complex compound messages make much sense - they require a much more complex ui and also cause larger problems in flaky networks as there is only one "large" message to sent. just came into my mind as the flaky network discussion is currently ongoing :)