### PR TITLE
copy files before dc_msg_send() returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ https://github.com/deltachat/deltachat-core/commits/master
 For a high-level overview about changes anywhere in the Delta Chat ecosystem,
 see https://delta.chat/en/changelog
 
+
+## v0.22.0
+2018-10-11
+
+* dc_send_msg() creates a copy of passed files before returning
+* the event DC_EVENT_FILE_COPIED is no longer used
+
+
 ## v0.21.0
 2018-10-11
 

--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -235,6 +235,9 @@ void stress_functions(dc_context_t* context)
 		assert( dc_get_filebytes(context, "$BLOBDIR/foobar")==7 );
 
 		char* absPath = dc_mprintf("%s/%s", context->blobdir, "foobar");
+		assert(  dc_is_in_blobdir(context, absPath) );
+		assert(  dc_is_in_blobdir(context, "$BLOBDIR/fofo") );
+		assert( !dc_is_in_blobdir(context, "/BLOBDIR/fofo") );
 		assert( dc_file_exist(context, absPath) );
 		free(absPath);
 

--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -235,9 +235,9 @@ void stress_functions(dc_context_t* context)
 		assert( dc_get_filebytes(context, "$BLOBDIR/foobar")==7 );
 
 		char* absPath = dc_mprintf("%s/%s", context->blobdir, "foobar");
-		assert(  dc_is_in_blobdir(context, absPath) );
-		assert(  dc_is_in_blobdir(context, "$BLOBDIR/fofo") );
-		assert( !dc_is_in_blobdir(context, "/BLOBDIR/fofo") );
+		assert(  dc_is_blobdir_path(context, absPath) );
+		assert(  dc_is_blobdir_path(context, "$BLOBDIR/fofo") );
+		assert( !dc_is_blobdir_path(context, "/BLOBDIR/fofo") );
 		assert( dc_file_exist(context, absPath) );
 		free(absPath);
 

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2133,6 +2133,19 @@ cleanup:
  * dc_send_msg(context, msg);
  * ~~~
  *
+ * You can even call this function if the file to be sent is still in creation.
+ * For this purpose, create a file with the additional extension `.increation`
+ * beside the file to sent. Once you're done with creating the file, delete the
+ * increation-file and the message will really be sent.
+ * This is useful as the user can already send the next messages while
+ * eg. the recoding of a video is not yet finished. Or the user can even forward
+ * the message with the file being still in creation to other groups.
+ *
+ * Files being sent with the increation-method must be placed in the
+ * blob directory, see dc_get_blobdir().
+ * If the increation-method is not used - which is probably the normal case -
+ * the file is copied to the blob directory if it is not yet there.
+ *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
  * @param chat_id Chat ID to send the message to.
@@ -2161,36 +2174,38 @@ uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 	else if (DC_MSG_NEEDS_ATTACHMENT(msg->type))
 	{
 		pathNfilename = dc_param_get(msg->param, DC_PARAM_FILE, NULL);
-		if (pathNfilename)
-		{
-			/* Got an attachment. Take care, the file may not be ready in this moment!
-			This is useful eg. if a video should be sent and already shown as "being processed" in the chat.
-			In this case, the user should create an `.increation`; when the file is deleted later on, the message is sent.
-			(we do not use a state in the database as this would make eg. forwarding such messages much more complicated) */
-
-			if (msg->type==DC_MSG_FILE || msg->type==DC_MSG_IMAGE)
-			{
-				/* Correct the type, take care not to correct already very special formats as GIF or VOICE.
-				Typical conversions:
-				- from FILE to AUDIO/VIDEO/IMAGE
-				- from FILE/IMAGE to GIF */
-				int   better_type = 0;
-				char* better_mime = NULL;
-				dc_msg_guess_msgtype_from_suffix(pathNfilename, &better_type, &better_mime);
-				if (better_type) {
-					msg->type = better_type;
-					dc_param_set(msg->param, DC_PARAM_MIMETYPE, better_mime);
-				}
-				free(better_mime);
-			}
-
-			dc_log_info(context, 0, "Attaching \"%s\" for message type #%i.", pathNfilename, (int)msg->type);
-		}
-		else
-		{
-			dc_log_error(context, 0, "Attachment missing for message of type #%i.", (int)msg->type); /* should not happen */
+		if (pathNfilename==NULL) {
+			dc_log_error(context, 0, "Attachment missing for message of type #%i.", (int)msg->type);
 			goto cleanup;
 		}
+
+		if (dc_msg_is_increation(msg) && !dc_is_in_blobdir(context, pathNfilename)) {
+			dc_log_error(context, 0, "Files must be created in the blob-directory.");
+			goto cleanup;
+		}
+
+		if (!dc_make_rel_and_copy(context, &pathNfilename)) {
+			goto cleanup;
+		}
+		dc_param_set(msg->param, DC_PARAM_FILE, pathNfilename);
+
+		if (msg->type==DC_MSG_FILE || msg->type==DC_MSG_IMAGE)
+		{
+			/* Correct the type, take care not to correct already very special formats as GIF or VOICE.
+			Typical conversions:
+			- from FILE to AUDIO/VIDEO/IMAGE
+			- from FILE/IMAGE to GIF */
+			int   better_type = 0;
+			char* better_mime = NULL;
+			dc_msg_guess_msgtype_from_suffix(pathNfilename, &better_type, &better_mime);
+			if (better_type) {
+				msg->type = better_type;
+				dc_param_set(msg->param, DC_PARAM_MIMETYPE, better_mime);
+			}
+			free(better_mime);
+		}
+
+		dc_log_info(context, 0, "Attaching \"%s\" for message type #%i.", pathNfilename, (int)msg->type);
 	}
 	else
 	{

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2179,7 +2179,7 @@ uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 			goto cleanup;
 		}
 
-		if (dc_msg_is_increation(msg) && !dc_is_in_blobdir(context, pathNfilename)) {
+		if (dc_msg_is_increation(msg) && !dc_is_blobdir_path(context, pathNfilename)) {
 			dc_log_error(context, 0, "Files must be created in the blob-directory.");
 			goto cleanup;
 		}

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -334,12 +334,6 @@ static void dc_job_do_DC_JOB_SEND_MSG_TO_SMTP(dc_context_t* context, dc_job_t* j
 	if (DC_MSG_NEEDS_ATTACHMENT(mimefactory.msg->type)) {
 		char* pathNfilename = dc_param_get(mimefactory.msg->param, DC_PARAM_FILE, NULL);
 		if (pathNfilename) {
-			if (!dc_make_rel_and_copy(context, &pathNfilename)) {
-				dc_set_msg_failed(context, job->foreign_id, "Cannot copy file to internal directory.");
-				goto cleanup;
-			}
-			dc_param_set(mimefactory.msg->param, DC_PARAM_FILE, pathNfilename);
-
 			/* set width/height of images, if not yet done */
 			if ((mimefactory.msg->type==DC_MSG_IMAGE || mimefactory.msg->type==DC_MSG_GIF)
 			 && !dc_param_exists(mimefactory.msg->param, DC_PARAM_WIDTH)) {
@@ -353,9 +347,8 @@ static void dc_job_do_DC_JOB_SEND_MSG_TO_SMTP(dc_context_t* context, dc_job_t* j
 					}
 				}
 				free(buf);
+				dc_msg_save_param_to_disk(mimefactory.msg);
 			}
-
-			dc_msg_save_param_to_disk(mimefactory.msg);
 		}
 	}
 

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -1431,10 +1431,10 @@ void dc_make_rel_path(dc_context_t* context, char** path)
 
 /**
  * Check if a path describes a file in the blob directory.
- * The path can be give absolute or relative (starting with `$BLOBDIR`).
+ * The path can be absolute or relative (starting with `$BLOBDIR`).
  * The function does not check if the file really exists.
  */
-int dc_is_in_blobdir(dc_context_t* context, const char* path)
+int dc_is_blobdir_path(dc_context_t* context, const char* path)
 {
 	if ((strncmp(path, context->blobdir, strlen(context->blobdir))==0)
 	 || (strncmp(path, "$BLOBDIR", 8)==0)) {
@@ -1462,7 +1462,7 @@ int dc_make_rel_and_copy(dc_context_t* context, char** path)
 		goto cleanup;
 	}
 
-	if (dc_is_in_blobdir(context, *path)) {
+	if (dc_is_blobdir_path(context, *path)) {
 		dc_make_rel_path(context, path);
 		success = 1; // file is already in blobdir
 		goto cleanup;

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -1474,8 +1474,6 @@ int dc_make_rel_and_copy(dc_context_t* context, char** path)
 		goto cleanup;
 	}
 
-	context->cb(context, DC_EVENT_FILE_COPIED, (uintptr_t)(*path), 0);
-
 	free(*path);
 	*path = blobdir_path;
 	blobdir_path = NULL;

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -1430,6 +1430,21 @@ void dc_make_rel_path(dc_context_t* context, char** path)
 
 
 /**
+ * Check if a path describes a file in the blob directory.
+ * The path can be give absolute or relative (starting with `$BLOBDIR`).
+ * The function does not check if the file really exists.
+ */
+int dc_is_in_blobdir(dc_context_t* context, const char* path)
+{
+	if ((strncmp(path, context->blobdir, strlen(context->blobdir))==0)
+	 || (strncmp(path, "$BLOBDIR", 8)==0)) {
+		return 1;
+	}
+	return 0;
+}
+
+
+/**
  * Copy a file to the blob directory, if needed.
  *
  * @param context The context object as returned from dc_context_new().
@@ -1447,8 +1462,7 @@ int dc_make_rel_and_copy(dc_context_t* context, char** path)
 		goto cleanup;
 	}
 
-	if ((strncmp(*path, context->blobdir, strlen(context->blobdir))==0)
-	 || (strncmp(*path, "$BLOBDIR", 8)==0)) {
+	if (dc_is_in_blobdir(context, *path)) {
 		dc_make_rel_path(context, path);
 		success = 1; // file is already in blobdir
 		goto cleanup;

--- a/src/dc_tools.h
+++ b/src/dc_tools.h
@@ -110,7 +110,7 @@ int      dc_create_folder           (dc_context_t*, const char* pathNfilename);
 int      dc_write_file              (dc_context_t*, const char* pathNfilename, const void* buf, size_t buf_bytes);
 int      dc_read_file               (dc_context_t*, const char* pathNfilename, void** buf, size_t* buf_bytes);
 char*    dc_get_fine_pathNfilename  (dc_context_t*, const char* pathNfolder, const char* desired_name);
-int      dc_is_in_blobdir           (dc_context_t*, const char* path);
+int      dc_is_blobdir_path         (dc_context_t*, const char* path);
 void     dc_make_rel_path           (dc_context_t*, char** pathNfilename);
 int      dc_make_rel_and_copy       (dc_context_t*, char** pathNfilename);
 

--- a/src/dc_tools.h
+++ b/src/dc_tools.h
@@ -110,6 +110,7 @@ int      dc_create_folder           (dc_context_t*, const char* pathNfilename);
 int      dc_write_file              (dc_context_t*, const char* pathNfilename, const void* buf, size_t buf_bytes);
 int      dc_read_file               (dc_context_t*, const char* pathNfilename, void** buf, size_t* buf_bytes);
 char*    dc_get_fine_pathNfilename  (dc_context_t*, const char* pathNfolder, const char* desired_name);
+int      dc_is_in_blobdir           (dc_context_t*, const char* path);
 void     dc_make_rel_path           (dc_context_t*, char** pathNfilename);
 int      dc_make_rel_and_copy       (dc_context_t*, char** pathNfilename);
 

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 
-#define DC_VERSION_STR "0.21.0"
+#define DC_VERSION_STR "0.22.0"
 
 
 /**

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -949,24 +949,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 
 /**
- * A file has been copied. Files given to dc_set_chat_profile_image(),
- * dc_send_msg() and related functions are copied to the internal blob directory
- * unless they are already there.
- *
- * After copying, this event is sent; from that moment on,
- * the given file is no longer needed by the library and it is safe to delete it
- * (eg. in case it was generated for sending only - if you send images from the
- * gallery you may not want to delete them afterwards).
- *
- * @param data1 (const char*) Path and file name.
- *     Must not be free()'d or modified and is valid only until the callback returns.
- * @param data2 0
- * @return 0
- */
-#define DC_EVENT_FILE_COPIED              2055
-
-
-/**
  * Progress information of a secure-join handshake from the view of the inviter
  * (Alice, the person who shows the QR code).
  *
@@ -1060,6 +1042,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  * @}
  */
 
+#define DC_EVENT_FILE_COPIED         2055 // deprecated
 #define DC_EVENT_DATA1_IS_STRING(e)  ((e)==DC_EVENT_HTTP_GET || (e)==DC_EVENT_IMEX_FILE_WRITTEN || (e)==DC_EVENT_FILE_COPIED)
 #define DC_EVENT_DATA2_IS_STRING(e)  ((e)==DC_EVENT_INFO || (e) == DC_EVENT_WARNING || (e) == DC_EVENT_ERROR || (e) == DC_EVENT_SMTP_CONNECTED || (e) == DC_EVENT_SMTP_MESSAGE_SENT || (e) == DC_EVENT_IMAP_CONNECTED)
 #define DC_EVENT_RETURNS_INT(e)      ((e)==DC_EVENT_IS_OFFLINE)


### PR DESCRIPTION
this pr copies files before dc_msg_send() returns instead of postponing the copy action to the smtp-thread.

as files given to dc_msg_send() are no longer needed after dc_msg_send() returns, the event DC_EVENT_FILE_COPIED is no longer needed (eg. files can be deleted at once and without waiting for an event).

this change should make the overall usage of the sending message API easier and closes #374