### PR TITLE
remove log excerpt from dc_get_info()

### DIFF
--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -89,14 +89,6 @@ struct _dc_context
 
 	uint32_t         cmdline_sel_chat_id;   /**< Internal */
 
-	#define          DC_LOG_RINGBUF_SIZE 200
-	pthread_mutex_t  log_ringbuf_critical;  /**< Internal */
-	char*            log_ringbuf[DC_LOG_RINGBUF_SIZE];
-	                                          /**< Internal */
-	time_t           log_ringbuf_times[DC_LOG_RINGBUF_SIZE];
-	                                          /**< Internal */
-	int              log_ringbuf_pos;       /**< Internal. The oldest position resp. the position that is overwritten next */
-
 	// QR code scanning (view from Bob, the joiner)
 	#define          DC_VC_AUTH_REQUIRED     2
 	#define          DC_VC_CONTACT_CONFIRM   6

--- a/src/dc_log.c
+++ b/src/dc_log.c
@@ -68,14 +68,6 @@ static void log_vprintf(dc_context_t* context, int event, int code, const char* 
 
 	/* finally, log */
 	context->cb(context, event, (uintptr_t)code, (uintptr_t)msg);
-
-	/* remember the last N log entries */
-	pthread_mutex_lock(&context->log_ringbuf_critical);
-		free(context->log_ringbuf[context->log_ringbuf_pos]);
-		context->log_ringbuf[context->log_ringbuf_pos] = msg;
-		context->log_ringbuf_times[context->log_ringbuf_pos] = time(NULL);
-		context->log_ringbuf_pos = (context->log_ringbuf_pos+1) % DC_LOG_RINGBUF_SIZE;
-	pthread_mutex_unlock(&context->log_ringbuf_critical);
 }
 
 


### PR DESCRIPTION
the remaining return value of dc_get_info() are plain key=value lines, so i also removed the initial headline.

i did not add a special function for getting the log excerpt back in another way; if needed by some implementation, these could easily do the stuff that is removed in this pr in their callbacks, however, i think for most implementations not even this is needed as the "delta log lines" may be retrieved in the system log - together with other, non-delta, valuable information.

closes #386