### PR TITLE
add a switch and a function to get mime-headers

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ def main():
         long_description = long_description,
         author='holger krekel, bjoern petersen and contributors',
         setup_requires=['cffi>=1.0.0'],
-        install_requires=['cffi>=1.0.0', 'requests', 'attrs'],
+        install_requires=['cffi>=1.0.0', 'requests', 'attrs', 'six'],
         packages=setuptools.find_packages('src'),
         package_dir={'': 'src'},
         cffi_modules=['src/deltachat/_build.py:ffibuilder'],

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import threading
+import six
 import re
 import time
 import requests
@@ -221,6 +222,25 @@ class Account(object):
     def get_message_by_id(self, msg_id):
         """ return Message instance. """
         return Message.from_db(self._dc_context, msg_id)
+
+    def get_mime_headers(self, msg_id):
+        """ return mime-header object for an incoming message.
+
+        This only returns a non-None object if ``save_mime_headers``
+        config option was set and ``msg_id`` refers to an incoming
+        message.
+
+        :param msg_id: integer message id
+        :returns: email-mime message object.
+        """
+        import email.parser
+        mime_headers = lib.dc_get_mime_headers(self._dc_context, msg_id)
+        if mime_headers:
+            s = ffi.string(mime_headers)
+            if isinstance(s, bytes):
+                s = s.decode("ascii")
+            fp = six.StringIO(s)
+            return email.parser.Parser().parse(fp)
 
     def mark_seen_messages(self, messages):
         """ mark the given set of messages as seen.

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -348,6 +348,7 @@ static char* get_sys_config_str(const char* key)
 		       " server_flags displayname"
 		       " selfstatus selfavatar"
 		       " e2ee_enabled mdns_enabled"
+		       " save_mime_headers"
 		       " sys.version sys.msgsize_max_recommended sys.config_keys");
 	}
 	else {

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -376,6 +376,7 @@ static char* get_sys_config_str(const char* key)
  * - `e2ee_enabled` = 0=no end-to-end-encryption, 1=prefer end-to-end-encryption (default)
  * - `mdns_enabled` = 0=do not send or request read receipts,
  *                    1=send and request read receipts
+ * - `save_mime_headers` = set this to "1" if you want to use dc_get_mime_headers() later
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -382,19 +382,6 @@ static void dc_job_do_DC_JOB_SEND_MSG_TO_SMTP(dc_context_t* context, dc_job_t* j
 	/* done */
 	dc_sqlite3_begin_transaction(context->sql);
 
-		/* debug print? */
-		if (dc_sqlite3_get_config_int(context->sql, "save_eml", 0)) {
-			char* emlname = dc_mprintf("%s/to-smtp-%i.eml", context->blobdir, (int)mimefactory.msg->id);
-			FILE* emlfileob = fopen(emlname, "w");
-			if (emlfileob) {
-				if (mimefactory.out) {
-					fwrite(mimefactory.out->str, 1, mimefactory.out->len, emlfileob);
-				}
-				fclose(emlfileob);
-			}
-			free(emlname);
-		}
-
 		dc_update_msg_state(context, mimefactory.msg->id, DC_STATE_OUT_DELIVERED);
 		if (mimefactory.out_encrypted && dc_param_get_int(mimefactory.msg->param, DC_PARAM_GUARANTEE_E2EE, 0)==0) {
 			dc_param_set_int(mimefactory.msg->param, DC_PARAM_GUARANTEE_E2EE, 1); /* can upgrade to E2EE - fine! */

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -485,6 +485,16 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			}
 		#undef NEW_DB_VERSION
 
+		#define NEW_DB_VERSION 44
+			if (dbversion < NEW_DB_VERSION)
+			{
+				dc_sqlite3_execute(sql, "ALTER TABLE msgs ADD COLUMN mime_headers TEXT;");
+
+				dbversion = NEW_DB_VERSION;
+				dc_sqlite3_set_config_int(sql, "dbversion", NEW_DB_VERSION);
+			}
+		#undef NEW_DB_VERSION
+
 
 		// (2) updates that require high-level objects
 		// (the structure is complete now and all objects are usable)

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -114,8 +114,10 @@ cleanup:
 uint32_t dc_sqlite3_get_rowid(dc_sqlite3_t* sql, const char* table, const char* field, const char* value)
 {
 	// alternative to sqlite3_last_insert_rowid() which MUST NOT be used due to race conditions, see comment above.
+	// the ORDER BY ensures, this function always returns the most recent id,
+	// eg. if a Message-ID is splitted into different messages.
 	uint32_t id = 0;
-	char* q3 = sqlite3_mprintf("SELECT id FROM %s WHERE %s=%Q;", table, field, value);
+	char* q3 = sqlite3_mprintf("SELECT id FROM %s WHERE %s=%Q ORDER BY id DESC;", table, field, value);
 	sqlite3_stmt* stmt = dc_sqlite3_prepare(sql, q3);
 	if (SQLITE_ROW==sqlite3_step(stmt)) {
 		id = sqlite3_column_int(stmt, 0);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -303,6 +303,7 @@ int             dc_set_chat_profile_image    (dc_context_t*, uint32_t chat_id, c
 
 // handle messages
 char*           dc_get_msg_info              (dc_context_t*, uint32_t msg_id);
+char*           dc_get_mime_headers          (dc_context_t*, uint32_t msg_id);
 void            dc_delete_msgs               (dc_context_t*, const uint32_t* msg_ids, int msg_cnt);
 void            dc_forward_msgs              (dc_context_t*, const uint32_t* msg_ids, int msg_cnt, uint32_t chat_id);
 void            dc_marknoticed_contact       (dc_context_t*, uint32_t contact_id);


### PR DESCRIPTION
- add a new function to get the mime-headers of messages, currently incoming only, dc_get_mime_headers()
- to collect the headers so that the function can word, one has to set the flag `save_mime_headers` using dc_set_config()

in contrast to my proposal in #365, i save the headers in a database as i do not want to mix files of too many different sources in the blob directory.