### PR TITLE
refine msg.time_sent to return a correct utc-based "naive" datetime…

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -223,7 +223,7 @@ class Account(object):
         """ return Message instance. """
         return Message.from_db(self._dc_context, msg_id)
 
-    def get_mime_headers(self, msg_id):
+    def get_mime_headers(self, msg):
         """ return mime-header object for an incoming message.
 
         This only returns a non-None object if ``save_mime_headers``
@@ -234,6 +234,7 @@ class Account(object):
         :returns: email-mime message object.
         """
         import email.parser
+        msg_id = getattr(msg, "id", msg)
         mime_headers = lib.dc_get_mime_headers(self._dc_context, msg_id)
         if mime_headers:
             s = ffi.string(mime_headers)

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -92,12 +92,12 @@ class Message(object):
 
     @property_with_doc
     def time_sent(self):
-        """time when the message was sent.
+        """time (utc) when the message was sent.
 
-        :returns: datetime.datetime() object.
+        :returns: naive datetime.datetime() object.
         """
         ts = lib.dc_msg_get_timestamp(self._dc_msg)
-        return datetime.fromtimestamp(ts)
+        return datetime.utcfromtimestamp(ts)
 
     @property
     def chat(self):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -178,7 +178,7 @@ class TestOfflineAccount:
         ac1 = acfactory.get_configured_offline_account()
         contact1 = ac1.create_contact("some1@hello.com", name="some1")
         chat = ac1.create_chat_by_contact(contact1)
-        past1s = datetime.now() - timedelta(seconds=1)
+        past1s = datetime.utcnow() - timedelta(seconds=1)
         msg = chat.send_text("msg1")
         ts = msg.time_sent
         assert ts.strftime("Y")
@@ -297,6 +297,7 @@ class TestOnlineAccount:
         mime = ac2.get_mime_headers(in_id)
         assert mime.get_all("From")
         assert mime.get_all("Received")
+        assert ac2.get_mime_headers(ac2.get_message_by_id(in_id)).get_all("From")
 
     def test_send_and_receive_image(self, acfactory, lp, data):
         lp.sec("starting accounts, waiting for configuration")


### PR DESCRIPTION
… object

-also: accept message objects instead of just ints for get_mime_headers(msg)