### PR TITLE
remove untidy and incomplete mediainfo functions

### DIFF
--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -470,8 +470,6 @@ void stress_functions(dc_context_t* context)
 		assert( DC_PARAM_HEIGHT == 'h' );
 		assert( DC_PARAM_DURATION == 'd' );
 		assert( DC_PARAM_MIMETYPE == 'm' );
-		assert( DC_PARAM_AUTHORNAME == 'N' );
-		assert( DC_PARAM_TRACKNAME == 'n' );
 		assert( DC_PARAM_FORWARDED == 'a' );
 		assert( DC_PARAM_UNPROMOTED == 'U' );
 

--- a/src/dc_lot.c
+++ b/src/dc_lot.c
@@ -44,8 +44,7 @@ dc_lot_t* dc_lot_new()
 /**
  * Frees an object containing a set of parameters.
  * If the set object contains strings, the strings are also freed with this function.
- * Set objects are created eg. by dc_chatlist_get_summary(), dc_msg_get_summary or by
- * dc_msg_get_mediainfo().
+ * Set objects are created eg. by dc_chatlist_get_summary() or dc_msg_get_summary().
  *
  * @memberof dc_lot_t
  * @param set The object to free.

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -376,16 +376,7 @@ static struct mailmime* build_body_file(const dc_msg_t* msg, const char* base_na
 			suffix? suffix : "dat");
 	}
 	else if (msg->type==DC_MSG_AUDIO) {
-		char* author = dc_param_get(msg->param, DC_PARAM_AUTHORNAME, NULL);
-		char* title = dc_param_get(msg->param, DC_PARAM_TRACKNAME, NULL);
-		if (author && author[0] && title && title[0] && suffix) {
-			filename_to_send = dc_mprintf("%s - %s.%s",  author, title, suffix); /* the separator ` - ` is used on the receiver's side to construct the information; we avoid using ID3-scanners for security purposes */
-		}
-		else {
-			filename_to_send = dc_get_filename(pathNfilename);
-		}
-		free(author);
-		free(title);
+		filename_to_send = dc_get_filename(pathNfilename);
 	}
 	else if (msg->type==DC_MSG_IMAGE || msg->type==DC_MSG_GIF) {
 		if (base_name==NULL) {

--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -989,16 +989,6 @@ static void do_add_single_file_part(dc_mimeparser_t* parser, int msg_type, int m
 		}
 	}
 
-	/* split author/title from the original filename (if we do it from the real filename, we'll also get numbers appended by dc_get_fine_pathNfilename()) */
-	if (msg_type==DC_MSG_AUDIO) {
-		char* author = NULL, *title = NULL;
-		dc_msg_get_authorNtitle_from_filename(desired_filename, &author, &title);
-		dc_param_set(part->param, DC_PARAM_AUTHORNAME, author);
-		dc_param_set(part->param, DC_PARAM_TRACKNAME, title);
-		free(author);
-		free(title);
-	}
-
 	do_add_single_part(parser, part);
 	part = NULL;
 
@@ -1584,8 +1574,6 @@ void dc_mimeparser_parse(dc_mimeparser_t* mimeparser, const char* body_not_termi
 		if (part->type==DC_MSG_AUDIO) {
 			if (dc_mimeparser_lookup_optional_field(mimeparser, "Chat-Voice-Message")) {
 				part->type = DC_MSG_VOICE;
-				dc_param_set(part->param, DC_PARAM_AUTHORNAME, NULL); /* remove unneeded information */
-				dc_param_set(part->param, DC_PARAM_TRACKNAME, NULL);
 			}
 		}
 

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -94,7 +94,6 @@ int             dc_msg_is_increation                  (const dc_msg_t*);
 char*           dc_msg_get_summarytext_by_raw         (int type, const char* text, dc_param_t*, int approx_bytes, dc_context_t*); /* the returned value must be free()'d */
 void            dc_msg_save_param_to_disk             (dc_msg_t*);
 void            dc_msg_guess_msgtype_from_suffix      (const char* pathNfilename, int* ret_msgtype, char** ret_mime);
-void            dc_msg_get_authorNtitle_from_filename (const char* pathNfilename, char** ret_author, char** ret_title);
 
 #define DC_MSG_NEEDS_ATTACHMENT(a)         ((a)==DC_MSG_IMAGE || (a)==DC_MSG_GIF || (a)==DC_MSG_AUDIO || (a)==DC_MSG_VOICE || (a)==DC_MSG_VIDEO || (a)==DC_MSG_FILE)
 

--- a/src/dc_param.h
+++ b/src/dc_param.h
@@ -48,8 +48,6 @@ typedef struct dc_param_t
 #define DC_PARAM_HEIGHT            'h'  /* for msgs */
 #define DC_PARAM_DURATION          'd'  /* for msgs */
 #define DC_PARAM_MIMETYPE          'm'  /* for msgs */
-#define DC_PARAM_AUTHORNAME        'N'  /* for msgs: name of author or artist */
-#define DC_PARAM_TRACKNAME         'n'  /* for msgs: name of author or artist */
 #define DC_PARAM_GUARANTEE_E2EE    'c'  /* for msgs: incoming: message is encryoted, outgoing: guarantee E2EE or the message is not send */
 #define DC_PARAM_ERRONEOUS_E2EE    'e'  /* for msgs: decrypted with validation errors or without mutual set, if neither 'c' nor 'e' are preset, the messages is only transport encrypted */
 #define DC_PARAM_FORCE_PLAINTEXT   'u'  /* for msgs: force unencrypted message, either DC_FP_ADD_AUTOCRYPT_HEADER (1), DC_FP_NO_AUTOCRYPT_HEADER (2) or 0 */

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -500,7 +500,6 @@ char*           dc_msg_get_file              (const dc_msg_t*);
 char*           dc_msg_get_filename          (const dc_msg_t*);
 char*           dc_msg_get_filemime          (const dc_msg_t*);
 uint64_t        dc_msg_get_filebytes         (const dc_msg_t*);
-dc_lot_t*       dc_msg_get_mediainfo         (const dc_msg_t*);
 int             dc_msg_get_width             (const dc_msg_t*);
 int             dc_msg_get_height            (const dc_msg_t*);
 int             dc_msg_get_duration          (const dc_msg_t*);
@@ -518,7 +517,6 @@ void            dc_msg_set_text              (dc_msg_t*, const char* text);
 void            dc_msg_set_file              (dc_msg_t*, const char* file, const char* filemime);
 void            dc_msg_set_dimension         (dc_msg_t*, int width, int height);
 void            dc_msg_set_duration          (dc_msg_t*, int duration);
-void            dc_msg_set_mediainfo         (dc_msg_t*, const char* author, const char* trackname);
 void            dc_msg_latefiling_mediasize  (dc_msg_t*, int width, int height, int duration);
 
 
@@ -559,7 +557,7 @@ int             dc_contact_is_verified       (dc_contact_t*);
  * @class dc_lot_t
  *
  * An object containing a set of values.  The meaning of the values is defined by the function returning the set object.
- * Set objects are created eg. by dc_chatlist_get_summary(), dc_msg_get_summary() or by dc_msg_get_mediainfo().
+ * Set objects are created eg. by dc_chatlist_get_summary() or dc_msg_get_summary().
  *
  * NB: _Lot_ is used in the meaning _heap_ here.
  */


### PR DESCRIPTION
this pr removes the functions dc_msg_get_mediainfo() and dc_msg_set_mediainfo() that was meant to be used to set an author and a trackname for a media file.

however, i think these functions were a bit overambitious. also they are not well supported. eg. the information are written partly to the filename and also read from there as there is no easy way to pass them to a media file (id3 is too special).

also these functions were very special - they are only used when sending mp3 music files - might me that i was too close to my old silverjuke-project in the beginning :)

finally, only author and trackname are not even suffient, to do things right, we would need probably much more.

so - i would suggest to remove them. it seems to be totally fine to display the filename of mp3 files - as done for all other documents as well, so no special handling.