### PR TITLE
steps towards single-folder milestone

### DIFF
--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -412,6 +412,29 @@ void stress_functions(dc_context_t* context)
 		assert( strcmp(str, "")==0 );
 		free(str);
 
+		clist* list = dc_str_to_clist(NULL, " ");
+		assert( clist_count(list)==0 );
+		clist_free_content(list);
+		clist_free(list);
+
+		list = dc_str_to_clist("", " ");
+		assert( clist_count(list)==1 );
+		clist_free_content(list);
+		clist_free(list);
+
+		list = dc_str_to_clist(" ", " ");
+		assert( clist_count(list)==2 );
+		clist_free_content(list);
+		clist_free(list);
+
+		list = dc_str_to_clist("foo bar test", " ");
+		assert(clist_count(list)==3);
+		str = dc_str_from_clist(list, " ");
+		assert( strcmp(str, "foo bar test")==0 );
+		clist_free_content(list);
+		clist_free(list);
+		free(str);
+
 		assert( strcmp("fresh="     DC_STRINGIFY(DC_STATE_IN_FRESH),      "fresh=10")==0 ); /* these asserts check the values, the existance of the macros and also DC_STRINGIFY() */
 		assert( strcmp("noticed="   DC_STRINGIFY(DC_STATE_IN_NOTICED),    "noticed=13")==0 );
 		assert( strcmp("seen="      DC_STRINGIFY(DC_STATE_IN_SEEN),       "seen=16")==0 );

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2141,8 +2141,9 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 	}
 	dc_param_set(msg->param, DC_PARAM_ERRONEOUS_E2EE, NULL); /* reset eg. on forwarding */
 
-	// setup In-Reply-To: and corresponding fields
-	// according to RFC 5322 3.6.4, page 25
+	// set "In-Reply-To:" to identify the message to which the composed message is a reply;
+	// set "References:" to identify the "thread" of the conversation;
+	// both according to RFC 5322 3.6.4, page 25
 	if (get_parent_mime_headers(chat, &parent_rfc724_mid, &parent_in_reply_to, &parent_references)) {
 		if (parent_rfc724_mid && parent_rfc724_mid[0]) {
 			new_in_reply_to = dc_strdup(parent_rfc724_mid);

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -1986,7 +1986,9 @@ static int last_msg_in_chat_encrypted(dc_sqlite3_t* sql, uint32_t chat_id)
 
 static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_msg_t* msg, time_t timestamp)
 {
-	char*         rfc724_mid = NULL;
+	char*         new_rfc724_mid = NULL;
+	char*         new_references = NULL;
+	char*         new_in_reply_to = NULL;
 	sqlite3_stmt* stmt = NULL;
 	uint32_t      msg_id = 0;
 	uint32_t      to_id = 0;
@@ -2007,7 +2009,7 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 			dc_log_error(context, 0, "Cannot send message, not configured.");
 			goto cleanup;
 		}
-		rfc724_mid = dc_create_outgoing_rfc724_mid(DC_CHAT_TYPE_IS_MULTI(chat->type)? chat->grpid : NULL, from);
+		new_rfc724_mid = dc_create_outgoing_rfc724_mid(DC_CHAT_TYPE_IS_MULTI(chat->type)? chat->grpid : NULL, from);
 		free(from);
 	}
 
@@ -2085,10 +2087,49 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 	}
 	dc_param_set(msg->param, DC_PARAM_ERRONEOUS_E2EE, NULL); /* reset eg. on forwarding */
 
+	// setup In-Reply-To: and corresponding fields
+	// according to RFC 5322 3.6.4, page 25
+	stmt = dc_sqlite3_prepare(context->sql,
+		"SELECT rfc724_mid, mime_in_reply_to, mime_references"
+		" FROM msgs"
+		" WHERE timestamp=(SELECT max(timestamp) FROM msgs WHERE chat_id=? AND from_id!=?);");
+	sqlite3_bind_int  (stmt, 1, chat->id);
+	sqlite3_bind_int  (stmt, 2, DC_CONTACT_ID_SELF);
+	if (sqlite3_step(stmt)) {
+		const char* parent_rfc724_mid  = (const char*)sqlite3_column_text(stmt, 0);
+		const char* parent_in_reply_to = (const char*)sqlite3_column_text(stmt, 1);
+		const char* parent_references  = (const char*)sqlite3_column_text(stmt, 2);
+
+		if (parent_rfc724_mid && parent_rfc724_mid[0]) {
+			new_in_reply_to = dc_strdup(parent_rfc724_mid);
+		}
+
+		if (parent_references && parent_references[0]
+		 && parent_rfc724_mid && parent_rfc724_mid[0]) {
+			// angle brackets are added by the mimefactory later
+			new_references = dc_mprintf("%s %s", parent_references, parent_rfc724_mid);
+		}
+		else if (parent_references && parent_references[0]) {
+			new_references = dc_strdup(parent_references);
+		}
+		else if (parent_in_reply_to && parent_in_reply_to[0]
+		      && parent_rfc724_mid && parent_rfc724_mid[0]) {
+			new_references = dc_mprintf("%s %s", parent_in_reply_to, parent_rfc724_mid);
+		}
+		else if (parent_in_reply_to && parent_in_reply_to[0]) {
+			new_references = dc_strdup(parent_in_reply_to);
+		}
+	}
+	sqlite3_finalize(stmt);
+	stmt = NULL;
+
 	/* add message to the database */
 	stmt = dc_sqlite3_prepare(context->sql,
-		"INSERT INTO msgs (rfc724_mid,chat_id,from_id,to_id, timestamp,type,state, txt,param,hidden) VALUES (?,?,?,?, ?,?,?, ?,?,?);");
-	sqlite3_bind_text (stmt,  1, rfc724_mid, -1, SQLITE_STATIC);
+		"INSERT INTO msgs (rfc724_mid, chat_id, from_id, to_id, timestamp,"
+		" type, state, txt, param, hidden,"
+		" mime_in_reply_to, mime_references)"
+		" VALUES (?,?,?,?,?, ?,?,?,?,?, ?,?);");
+	sqlite3_bind_text (stmt,  1, new_rfc724_mid, -1, SQLITE_STATIC);
 	sqlite3_bind_int  (stmt,  2, chat->id);
 	sqlite3_bind_int  (stmt,  3, DC_CONTACT_ID_SELF);
 	sqlite3_bind_int  (stmt,  4, to_id);
@@ -2098,16 +2139,20 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 	sqlite3_bind_text (stmt,  8, msg->text? msg->text : "",  -1, SQLITE_STATIC);
 	sqlite3_bind_text (stmt,  9, msg->param->packed, -1, SQLITE_STATIC);
 	sqlite3_bind_int  (stmt, 10, msg->hidden);
+	sqlite3_bind_text (stmt, 11, new_in_reply_to, -1, SQLITE_STATIC);
+	sqlite3_bind_text (stmt, 12, new_references, -1, SQLITE_STATIC);
 	if (sqlite3_step(stmt)!=SQLITE_DONE) {
 		dc_log_error(context, 0, "Cannot send message, cannot insert to database.", chat->id);
 		goto cleanup;
 	}
 
-	msg_id = dc_sqlite3_get_rowid(context->sql, "msgs", "rfc724_mid", rfc724_mid);
+	msg_id = dc_sqlite3_get_rowid(context->sql, "msgs", "rfc724_mid", new_rfc724_mid);
 	dc_job_add(context, DC_JOB_SEND_MSG_TO_SMTP, msg_id, NULL, 0);
 
 cleanup:
-	free(rfc724_mid);
+	free(new_rfc724_mid);
+	free(new_in_reply_to);
+	free(new_references);
 	sqlite3_finalize(stmt);
 	return msg_id;
 }

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2014,7 +2014,7 @@ static int get_parent_mime_headers(const dc_chat_t* chat,
 	stmt = NULL;
 
 	if (!success) {
-		// there are not messages of other users - use the first message if SELF as parent
+		// there are no messages of other users - use the first message if SELF as parent
 		stmt = dc_sqlite3_prepare(chat->context->sql,
 			"SELECT rfc724_mid, mime_in_reply_to, mime_references"
 			" FROM msgs"

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2003,7 +2003,7 @@ static int get_parent_mime_headers(const dc_chat_t* chat,
 		" WHERE timestamp=(SELECT max(timestamp) FROM msgs WHERE chat_id=? AND from_id!=?);");
 	sqlite3_bind_int  (stmt, 1, chat->id);
 	sqlite3_bind_int  (stmt, 2, DC_CONTACT_ID_SELF);
-	if (sqlite3_step(stmt)) {
+	if (sqlite3_step(stmt)==SQLITE_ROW) {
 		*parent_rfc724_mid  = dc_strdup((const char*)sqlite3_column_text(stmt, 0));
 		*parent_in_reply_to = dc_strdup((const char*)sqlite3_column_text(stmt, 1));
 		*parent_references  = dc_strdup((const char*)sqlite3_column_text(stmt, 2));

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -552,7 +552,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	{
 		/* NB: Checking GMa'l too often (<10 Minutes) may result in blocking, says https://github.com/itprojects/InboxPager/blob/HEAD/README.md#gmail-configuration
 		Also note https://www.google.com/settings/security/lesssecureapps */
-		param->server_flags |= DC_LP_AUTH_XOAUTH2 | DC_NO_EXTRA_IMAP_UPLOAD | DC_NO_MOVE_TO_CHATS;
+		param->server_flags |= DC_LP_AUTH_XOAUTH2;
 	}
 
 

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -416,6 +416,7 @@ static char* get_sys_config_str(const char* key)
  * - `send_pw`      = SMTP-password, guessed if left out
  * - `send_port`    = SMTP-port, guessed if left out
  * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
+ * - `imap_folder`  = IMAP-folder to use, defaults to `INBOX`
  * - `displayname`  = Own name to use when sending messages.  MUAs are allowed to spread this way eg. using CC, defaults to empty
  * - `selfstatus`   = Own status to display eg. in email footers, defaults to a standard text
  * - `selfavatar`   = File containing avatar. Will be copied to blob directory.
@@ -514,6 +515,9 @@ char* dc_get_config(dc_context_t* context, const char* key)
 		}
 		else if (strcmp(key, "mdns_enabled")==0) {
 			value = dc_mprintf("%i", DC_MDNS_DEFAULT_ENABLED);
+		}
+		else if (strcmp(key, "imap_folder")==0) {
+			value = dc_strdup("INBOX");
 		}
 		else {
 			value = dc_mprintf("");

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -26,6 +26,7 @@ static const char* config_keys[] = {
 	"send_pw",
 	"send_port"
 	"server_flags",
+	"imap_folder",
 	"displayname"
 	"selfstatus",
 	"selfavatar",

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -82,7 +82,6 @@ void       dc_imap_interrupt_idle    (dc_imap_t*);
 
 int        dc_imap_append_msg        (dc_imap_t*, time_t timestamp, const char* data_not_terminated, size_t data_bytes, char** ret_server_folder, uint32_t* ret_server_uid);
 
-#define    DC_MS_ALSO_MOVE          0x01
 #define    DC_MS_SET_MDNSent_FLAG   0x02
 #define    DC_MS_MDNSent_JUST_SET   0x10
 int        dc_imap_markseen_msg      (dc_imap_t*, const char* folder, uint32_t server_uid, int ms_flags, char** ret_server_folder, uint32_t* ret_server_uid, int* ret_ms_flags); /* only returns 0 on connection problems; we should try later again in this case */

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -37,15 +37,12 @@ typedef struct dc_imap_t
 	int                   connected;
 	mailimap*             etpan;   /* normally, if connected, etpan is also set; however, if a reconnection is required, we may lost this handle */
 
-	time_t                last_fullread_time;
-
 	int                   idle_set_up;
 	char*                 selected_folder;
 	int                   selected_folder_needs_expunge;
 	int                   should_reconnect;
 
 	int                   can_idle;
-	int                   has_xlist;
 	char                  imap_delimiter;/* IMAP Path separator. Set as a side-effect in list_folders__ */
 
 	pthread_cond_t        watch_cond;

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -46,8 +46,6 @@ typedef struct dc_imap_t
 
 	int                   can_idle;
 	int                   has_xlist;
-	char*                 moveto_folder;// Folder, where reveived chat messages should go to.  Normally DC_CHATS_FOLDER, may be NULL to leave them in the INBOX
-	char*                 sent_folder;  // Folder, where send messages should go to.  Normally DC_CHATS_FOLDER.
 	char                  imap_delimiter;/* IMAP Path separator. Set as a side-effect in list_folders__ */
 
 	pthread_cond_t        watch_cond;

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -365,12 +365,6 @@ static void dc_job_do_DC_JOB_SEND_MSG_TO_SMTP(dc_context_t* context, dc_job_t* j
 			dc_msg_save_param_to_disk(mimefactory.msg);
 		}
 
-		if ((context->imap->server_flags&DC_NO_EXTRA_IMAP_UPLOAD)==0
-		 && dc_param_get(mimefactory.chat->param, DC_PARAM_SELFTALK, 0)==0
-		 && dc_param_get_int(mimefactory.msg->param, DC_PARAM_CMD, 0)!=DC_CMD_SECUREJOIN_MESSAGE) {
-			dc_job_add(context, DC_JOB_SEND_MSG_TO_IMAP, mimefactory.msg->id, NULL, 0); /* send message to IMAP in another job */
-		}
-
 		// TODO: add to keyhistory
 		dc_add_to_keyhistory(context, NULL, 0, NULL, NULL);
 

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -308,11 +308,10 @@ static void dc_job_do_DC_JOB_SEND_MSG_TO_SMTP(dc_context_t* context, dc_job_t* j
 		goto cleanup;
 	}
 
-	/* copy the file to the internal blob directory (if it is not already there) */
+	/* set width/height of images, if not yet done */
 	if (DC_MSG_NEEDS_ATTACHMENT(mimefactory.msg->type)) {
 		char* pathNfilename = dc_param_get(mimefactory.msg->param, DC_PARAM_FILE, NULL);
 		if (pathNfilename) {
-			/* set width/height of images, if not yet done */
 			if ((mimefactory.msg->type==DC_MSG_IMAGE || mimefactory.msg->type==DC_MSG_GIF)
 			 && !dc_param_exists(mimefactory.msg->param, DC_PARAM_WIDTH)) {
 				unsigned char* buf = NULL; size_t buf_bytes; uint32_t w, h;

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -214,10 +214,6 @@ static void dc_job_do_DC_JOB_MARKSEEN_MSG_ON_IMAP(dc_context_t* context, dc_job_
 		in_ms_flags |= DC_MS_SET_MDNSent_FLAG;
 	}
 
-	if (msg->is_msgrmsg) {
-		in_ms_flags |= DC_MS_ALSO_MOVE;
-	}
-
 	if (dc_imap_markseen_msg(context->imap, msg->server_folder, msg->server_uid,
 		   in_ms_flags, &new_server_folder, &new_server_uid, &out_ms_flags)!=0)
 	{
@@ -261,7 +257,7 @@ static void dc_job_do_DC_JOB_MARKSEEN_MDN_ON_IMAP(dc_context_t* context, dc_job_
 		}
 	}
 
-	if (dc_imap_markseen_msg(context->imap, server_folder, server_uid, DC_MS_ALSO_MOVE, &new_server_folder, &new_server_uid, &out_ms_flags)==0) {
+	if (dc_imap_markseen_msg(context->imap, server_folder, server_uid, 0, &new_server_folder, &new_server_uid, &out_ms_flags)==0) {
 		dc_job_try_again_later(job, DC_AT_ONCE, NULL);
 	}
 

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -677,6 +677,10 @@ void dc_perform_imap_idle(dc_context_t* context)
 {
 	connect_to_imap(context, NULL); // also idle if connection fails because of not-configured, no-network, whatever. dc_imap_idle() will handle this by the fake-idle and log a warning
 
+	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC) {
+		return;
+	}
+
 	pthread_mutex_lock(&context->imapidle_condmutex);
 		if (context->perform_imap_jobs_needed) {
 			dc_log_info(context, 0, "IMAP-IDLE will not be started because of waiting jobs.");

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -14,7 +14,6 @@ extern "C" {
 #define DC_JOB_DELETE_MSG_ON_IMAP     110    // low priority ...
 #define DC_JOB_MARKSEEN_MDN_ON_IMAP   120
 #define DC_JOB_MARKSEEN_MSG_ON_IMAP   130
-#define DC_JOB_SEND_MSG_TO_IMAP       700
 #define DC_JOB_CONFIGURE_IMAP         900
 #define DC_JOB_IMEX_IMAP              910    // ... high priority
 

--- a/src/dc_loginparam.c
+++ b/src/dc_loginparam.c
@@ -114,9 +114,6 @@ static char* get_readable_flags(int flags)
 			CAT_FLAG(DC_LP_SMTP_SOCKET_SSL,      "SMTP_SSL ");
 			CAT_FLAG(DC_LP_SMTP_SOCKET_PLAIN,    "SMTP_PLAIN ");
 
-			CAT_FLAG(DC_NO_EXTRA_IMAP_UPLOAD, "NO_EXTRA_IMAP_UPLOAD ");
-			CAT_FLAG(DC_NO_MOVE_TO_CHATS,     "NO_MOVE_TO_CHATS ");
-
 			if (!flag_added) {
 				char* temp = dc_mprintf("0x%x ", 1<<bit); dc_strbuilder_cat(&strbuilder, temp); free(temp);
 			}

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -126,9 +126,13 @@ int dc_mimefactory_load_msg(dc_mimefactory_t* factory, uint32_t msg_id)
 
 			factory->req_mdn = 0;
 
+			if (dc_chat_is_self_talk(factory->chat))
+			{
 				clist_append(factory->recipients_names, (void*)dc_strdup_keep_null(factory->from_displayname));
 				clist_append(factory->recipients_addr,  (void*)dc_strdup(factory->from_addr));
-
+			}
+			else
+			{
 				stmt = dc_sqlite3_prepare(context->sql,
 					"SELECT c.authname, c.addr "
 					" FROM chats_contacts cc "
@@ -168,6 +172,7 @@ int dc_mimefactory_load_msg(dc_mimefactory_t* factory, uint32_t msg_id)
 				 && dc_sqlite3_get_config_int(context->sql, "mdns_enabled", DC_MDNS_DEFAULT_ENABLED)) {
 					factory->req_mdn = 1;
 				}
+			}
 
 			/* Get a predecessor of the mail to send.
 			For simplicity, we use the last message send not by us.

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -126,13 +126,9 @@ int dc_mimefactory_load_msg(dc_mimefactory_t* factory, uint32_t msg_id)
 
 			factory->req_mdn = 0;
 
-			if (dc_chat_is_self_talk(factory->chat))
-			{
 				clist_append(factory->recipients_names, (void*)dc_strdup_keep_null(factory->from_displayname));
 				clist_append(factory->recipients_addr,  (void*)dc_strdup(factory->from_addr));
-			}
-			else
-			{
+
 				stmt = dc_sqlite3_prepare(context->sql,
 					"SELECT c.authname, c.addr "
 					" FROM chats_contacts cc "
@@ -172,7 +168,6 @@ int dc_mimefactory_load_msg(dc_mimefactory_t* factory, uint32_t msg_id)
 				 && dc_sqlite3_get_config_int(context->sql, "mdns_enabled", DC_MDNS_DEFAULT_ENABLED)) {
 					factory->req_mdn = 1;
 				}
-			}
 
 			/* Get a predecessor of the mail to send.
 			For simplicity, we use the last message send not by us.

--- a/src/dc_mimefactory.h
+++ b/src/dc_mimefactory.h
@@ -43,7 +43,7 @@ typedef struct dc_mimefactory_t {
 	dc_msg_t*     msg;
 	dc_chat_t*    chat;
 	int           increation;
-	char*         predecessor;
+	char*         in_reply_to;
 	char*         references;
 	int           req_mdn;
 

--- a/src/dc_param.h
+++ b/src/dc_param.h
@@ -42,7 +42,6 @@ typedef struct dc_param_t
 #define DC_PARAM_SERVER_UID        'z'  /* for jobs */
 #define DC_PARAM_TIMES             't'  /* for jobs: times a job was tried */
 
-#define DC_PARAM_REFERENCES        'R'  /* for groups and chats: References-header last used for a chat */
 #define DC_PARAM_UNPROMOTED        'U'  /* for groups */
 #define DC_PARAM_PROFILE_IMAGE     'i'  /* for groups and contacts */
 #define DC_PARAM_SELFTALK          'K'  /* for chats */

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -473,6 +473,17 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			}
 		#undef NEW_DB_VERSION
 
+		#define NEW_DB_VERSION 46
+			if (dbversion < NEW_DB_VERSION)
+			{
+				dc_sqlite3_execute(sql, "ALTER TABLE msgs ADD COLUMN mime_in_reply_to TEXT;");
+				dc_sqlite3_execute(sql, "ALTER TABLE msgs ADD COLUMN mime_references TEXT;");
+
+				dbversion = NEW_DB_VERSION;
+				dc_sqlite3_set_config_int(sql, "dbversion", NEW_DB_VERSION);
+			}
+		#undef NEW_DB_VERSION
+
 
 		// (2) updates that require high-level objects
 		// (the structure is complete now and all objects are usable)

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -552,6 +552,58 @@ char* dc_insert_breaks(const char* in, int break_every, const char* break_chars)
 }
 
 
+// Join clist element to a string.
+char* dc_str_from_clist(const clist* list, const char* delimiter)
+{
+	dc_strbuilder_t str;
+	dc_strbuilder_init(&str, 256);
+
+	if (list) {
+		for (clistiter* cur = clist_begin(list); cur!=NULL ; cur=clist_next(cur)) {
+			const char* rfc724_mid = clist_content(cur);
+			if (rfc724_mid) {
+				if (str.buf[0] && delimiter) {
+					dc_strbuilder_cat(&str, delimiter);
+				}
+				dc_strbuilder_cat(&str, rfc724_mid);
+			}
+		}
+	}
+
+	return str.buf;
+}
+
+
+// Split a string by a character.
+// If the string is empty or NULL, an empty list is returned.
+// The returned clist must be freed using clist_free_content()+clist_free()
+// or given eg. to libetpan objects.
+clist* dc_str_to_clist(const char* str, const char* delimiter)
+{
+	clist* list = clist_new();
+	if (list==NULL) {
+		exit(54);
+	}
+
+	if (str && delimiter && strlen(delimiter)>=1) {
+		const char* p1 = str;
+		while (1) {
+			const char* p2 = strstr(p1, delimiter);
+			if (p2==NULL) {
+				clist_append(list,  (void*)strdup(p1));
+				break;
+			}
+			else {
+				clist_append(list, (void*)strndup(p1, p2-p1));
+				p1 = p2+strlen(delimiter);
+			}
+		}
+	}
+
+	return list;
+}
+
+
 /*******************************************************************************
  * clist tools
  ******************************************************************************/

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -898,16 +898,6 @@ char* dc_create_id(void)
 }
 
 
-char* dc_create_dummy_references_mid()
-{
-	char* msgid = dc_create_id();
-	char* ret = NULL;
-	ret = dc_mprintf("Rf.%s@mr.thread", msgid);
-	free(msgid);
-	return ret;
-}
-
-
 char* dc_create_outgoing_rfc724_mid(const char* grpid, const char* from_addr)
 {
 	/* Function generates a Message-ID that can be used for a new outgoing message.

--- a/src/dc_tools.h
+++ b/src/dc_tools.h
@@ -42,6 +42,8 @@ void    dc_truncate_n_unwrap_str   (char*, int approx_characters, int do_unwrap)
 carray* dc_split_into_lines        (const char* buf_terminated); /* split string into lines*/
 void    dc_free_splitted_lines     (carray* lines);
 char*   dc_insert_breaks           (const char*, int break_every, const char* break_chars); /* insert a break every n characters, the return must be free()'d */
+char*   dc_str_from_clist          (const clist*, const char* delimiter);
+clist*  dc_str_to_clist            (const char*, const char* delimiter);
 
 // from libetpan/src/data-types/base64.h (which cannot be included without adding libetpan/src/... to the include-search-paths, which would result in double-file-name-errors, so, for now, we use this hack)
 char*   encode_base64              (const char * in, int len);

--- a/src/dc_tools.h
+++ b/src/dc_tools.h
@@ -67,7 +67,6 @@ time_t dc_create_smeared_timestamps  (dc_context_t*, int count);
 /* Message-ID tools */
 #define DC_CREATE_ID_LEN                   11
 char* dc_create_id                         (void);
-char* dc_create_dummy_references_mid       (void);
 char* dc_create_incoming_rfc724_mid        (time_t message_timestamp, uint32_t contact_id_from, dc_array_t* contact_ids_to);
 char* dc_create_outgoing_rfc724_mid        (const char* grpid, const char* addr);
 char* dc_extract_grpid_from_rfc724_mid     (const char* rfc724_mid);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -700,8 +700,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  */
 
 #define DC_LP_AUTH_XOAUTH2               0x2
-#define DC_NO_EXTRA_IMAP_UPLOAD    0x2000000
-#define DC_NO_MOVE_TO_CHATS        0x4000000
 #define DC_LP_AUTH_FLAGS        (DC_LP_AUTH_XOAUTH2|DC_LP_AUTH_NORMAL) // if none of these flags are set, the default is choosen
 #define DC_LP_IMAP_SOCKET_FLAGS (DC_LP_IMAP_SOCKET_STARTTLS|DC_LP_IMAP_SOCKET_SSL|DC_LP_IMAP_SOCKET_PLAIN) // if none of these flags are set, the default is choosen
 #define DC_LP_SMTP_SOCKET_FLAGS (DC_LP_SMTP_SOCKET_STARTTLS|DC_LP_SMTP_SOCKET_SSL|DC_LP_SMTP_SOCKET_PLAIN) // if none of these flags are set, the default is choosen


### PR DESCRIPTION
- tackle #370 by forcing SELF being always on the recipient list
- tackle #370 by completely removing the call to the IMAP upload
- #371 is also tackled as the messages that arrive in the INBOX now are not moved to DeltaChat folder. EDIT: by 0123a064f9c6208d987df4a0b4c83b2d3863ea9c this is also true for incoming messages
 
to keep the changes more clear, currently reformatting is skipped; this can be done later. as well as removing dead code.

messages are not appearing twice as there is already a check for the Message-ID in dc_receive_imf(), so, for now, this is fine. later on, we can optimize this by checking the Message-ID without completely downloading the whole message.

closes #370, closes #371, closes #372, closes #72