### PR TITLE
Tweak DC_STR_MSGGROUPLEFT default message

### DIFF
--- a/src/dc_stock.c
+++ b/src/dc_stock.c
@@ -50,7 +50,7 @@ static char* default_string(int id)
 		case DC_STR_MSGGRPIMGCHANGED:      return dc_strdup("Group image changed.");
 		case DC_STR_MSGADDMEMBER:          return dc_strdup("Member %1$s added.");
 		case DC_STR_MSGDELMEMBER:          return dc_strdup("Member %1$s removed.");
-		case DC_STR_MSGGROUPLEFT:          return dc_strdup("Group left.");
+		case DC_STR_MSGGROUPLEFT:          return dc_strdup("Left group.");
 		case DC_STR_SELFNOTINGRP:          return dc_strdup("You must be a member of the group to perform this action.");
 		case DC_STR_NONETWORK:             return dc_strdup("No network available.");
 		case DC_STR_E2E_AVAILABLE:         return dc_strdup("End-to-end encryption available.");


### PR DESCRIPTION
Correct me if I'm wrong, but this message is sent out to the group from a member when _they_ leave the group, right? To me "Group left" means that it was the group that left and not the member.