### PR TITLE
Improve building of extension a little

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ libs/packagecache
 libs/zlib-1.2.11
 
 # ignore python binding stuff
+python/.tox/
+python/liveconfig
 python/src/deltachat/capi*so
 
 .*.swp

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,11 +1,10 @@
 import setuptools
 import os
 import re
-import distutils.log
+
 
 def main():
     long_description, version = read_meta()
-    distutils.log.set_verbosity(1)
     setuptools.setup(
         name='deltachat',
         version=version,

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,15 +1,16 @@
 import setuptools
 import os
 import re
-
+import distutils.log
 
 def main():
     long_description, version = read_meta()
+    distutils.log.set_verbosity(1)
     setuptools.setup(
         name='deltachat',
         version=version,
         description='Python bindings for deltachat-core using CFFI',
-        long_description = long_description,
+        long_description=long_description,
         author='holger krekel, bjoern petersen and contributors',
         setup_requires=['cffi>=1.0.0'],
         install_requires=['cffi>=1.0.0', 'requests', 'attrs', 'six'],
@@ -28,8 +29,6 @@ def main():
 
 
 def read_meta():
-    with open('README.rst') as fd:
-        long_description = fd.read()
     with open(os.path.join("src", "deltachat", "__init__.py")) as f:
         for line in f:
             m = re.match('__version__ = "(\S*).*"', line)
@@ -43,4 +42,3 @@ def read_meta():
 
 if __name__ == "__main__":
     main()
-

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -57,5 +57,7 @@ def ffibuilder():
 
 
 if __name__ == '__main__':
+    import os.path
+    pkgdir = os.path.join(os.path.dirname(__file__), '..')
     builder = ffibuilder()
-    builder.compile(verbose=True)
+    builder.compile(tmpdir=pkgdir, verbose=True)

--- a/python/src/deltachat/chatting.py
+++ b/python/src/deltachat/chatting.py
@@ -1,9 +1,10 @@
 """ chatting related objects: Contact, Chat, Message. """
 
 import os
+
+from . import props
 from .cutil import as_dc_charpointer, from_dc_charpointer, iter_array
 from .capi import lib, ffi
-from .types import property_with_doc
 from . import const
 import attr
 from attr import validators as v
@@ -26,12 +27,12 @@ class Contact(object):
             lib.dc_contact_unref
         )
 
-    @property_with_doc
+    @props.with_doc
     def addr(self):
         """ normalized e-mail address for this account. """
         return from_dc_charpointer(lib.dc_contact_get_addr(self._dc_contact))
 
-    @property_with_doc
+    @props.with_doc
     def display_name(self):
         """ display name for this contact. """
         return from_dc_charpointer(lib.dc_contact_get_display_name(self._dc_contact))

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -1,9 +1,9 @@
 """ chatting related objects: Contact, Chat, Message. """
 
 import os
+from . import props
 from .cutil import from_dc_charpointer, as_dc_charpointer
 from .capi import lib, ffi
-from .types import property_with_doc
 from . import const
 from datetime import datetime
 import attr
@@ -55,7 +55,7 @@ class Message(object):
         """
         return MessageState(self)
 
-    @property_with_doc
+    @props.with_doc
     def text(self):
         """unicode text of this messages (might be empty if not a text message). """
         return from_dc_charpointer(lib.dc_msg_get_text(self._dc_msg))
@@ -64,7 +64,7 @@ class Message(object):
         """set text of this message. """
         return lib.dc_msg_set_text(self._dc_msg, as_dc_charpointer(text))
 
-    @property_with_doc
+    @props.with_doc
     def filename(self):
         """filename if there was an attachment, otherwise empty string. """
         return from_dc_charpointer(lib.dc_msg_get_file(self._dc_msg))
@@ -75,17 +75,17 @@ class Message(object):
         assert os.path.exists(path)
         lib.dc_msg_set_file(self._dc_msg, as_dc_charpointer(path), mtype)
 
-    @property_with_doc
+    @props.with_doc
     def basename(self):
         """basename of the attachment if it exists, otherwise empty string. """
         return from_dc_charpointer(lib.dc_msg_get_filename(self._dc_msg))
 
-    @property_with_doc
+    @props.with_doc
     def filemime(self):
         """mime type of the file (if it exists)"""
         return from_dc_charpointer(lib.dc_msg_get_filemime(self._dc_msg))
 
-    @property_with_doc
+    @props.with_doc
     def view_type(self):
         """the view type of this message.
 
@@ -93,7 +93,7 @@ class Message(object):
         """
         return MessageType(lib.dc_msg_get_viewtype(self._dc_msg))
 
-    @property_with_doc
+    @props.with_doc
     def time_sent(self):
         """UTC time when the message was sent.
 
@@ -102,7 +102,7 @@ class Message(object):
         ts = lib.dc_msg_get_timestamp(self._dc_msg)
         return datetime.utcfromtimestamp(ts)
 
-    @property_with_doc
+    @props.with_doc
     def time_received(self):
         """UTC time when the message was received.
 
@@ -168,7 +168,7 @@ class MessageType(object):
                 return code
         raise ValueError("message typecode not found for {!r}".format(view_type))
 
-    @property_with_doc
+    @props.with_doc
     def name(self):
         """ human readable type name. """
         return self._mapping.get(self._type, "")

--- a/python/src/deltachat/props.py
+++ b/python/src/deltachat/props.py
@@ -1,12 +1,13 @@
+"""Helpers for properties."""
 
-def property_with_doc(f):
+
+def with_doc(f):
     return property(f, None, None, f.__doc__)
 
 
 # copied over unmodified from
 # https://github.com/devpi/devpi/blob/master/common/devpi_common/types.py
-
-def cached_property(f):
+def cached(f):
     """returns a cached property that is calculated by function f"""
     def get(self):
         try:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import time
 from deltachat import Account
-from deltachat.types import cached_property
+from deltachat import props
 from deltachat.capi import lib
 
 
@@ -45,7 +45,7 @@ def acfactory(pytestconfig, tmpdir, request):
                 fin = self._finalizers.pop()
                 fin()
 
-        @cached_property
+        @props.cached
         def configlist(self):
             configlist = []
             for line in open(fn):


### PR DESCRIPTION
- This renames deltachat.types to deltachat.props.  Not re-using a
  stdlib name is somewhat nice and solves a weird edge-case for me where
  the deltachat.types module can be hiding stdlib types by the deltachat
  directory appearing before the stlib on sys.path.

- When manually invoking the build script (rather then via
  pip/setup.py) it figures out where the package actually lives and
  makes sure the .so file ends up in that directory.  This is better
  than the current version which depends on the current directory and
  thus sometimes creates an alternate deltachat/ directory tree.

- Add some common python artefact files to gitignore.