### PR TITLE
use exponential backoff

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -411,7 +411,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"configure\n"
 				"connect\n"
 				"disconnect\n"
-				"poll\n"
+				"maybenetwork\n"
 				"help imex (Import/Export)\n"
 				"==============================Chat commands==\n"
 				"listchats [<query>]\n"
@@ -638,6 +638,11 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 		if (ret == NULL) {
 			ret = COMMAND_FAILED;
 		}
+	}
+	else if (strcmp(cmd, "maybenetwork")==0)
+	{
+		dc_maybe_network(context);
+		ret = COMMAND_SUCCEEDED;
 	}
 
 	/*******************************************************************************

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,9 @@ endif
 # pthreads is not a real dependency
 pthreads = dependency('threads')
 
+# declare option to link against libm
+math = declare_dependency(link_args: ['-lm'])
+
 # zlib should move grow static-pic-lib support and be handled like
 # this as well.
 zlib = dependency('zlib', fallback: ['zlib', 'zlib_dep'])

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,8 @@ endif
 pthreads = dependency('threads')
 
 # declare option to link against libm
-math = declare_dependency(link_args: ['-lm'])
+cc = meson.get_compiler('c')
+math = cc.find_library('m')
 
 # zlib should move grow static-pic-lib support and be handled like
 # this as well.

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -50,6 +50,7 @@ struct _dc_context
 	dc_imap_t*       imap;                  /**< Internal IMAP object, never NULL */
 	pthread_mutex_t  imapidle_condmutex;
 	int              perform_imap_jobs_needed;
+	int              probe_imap_network;    /**< if this flag is set, the imap-job timeouts are bypassed and messages are sent until they fail */
 
 	dc_smtp_t*       smtp;                  /**< Internal SMTP object, never NULL */
 	pthread_cond_t   smtpidle_cond;
@@ -60,6 +61,7 @@ struct _dc_context
 	#define          DC_JOBS_NEEDED_AT_ONCE   1
 	#define          DC_JOBS_NEEDED_AVOID_DOS 2
 	int              perform_smtp_jobs_needed;
+	int              probe_smtp_network;   /**< if this flag is set, the smtp-job timeouts are bypassed and messages are sent until they fail */
 
 	dc_callback_t    cb;                    /**< Internal */
 

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -951,3 +951,23 @@ void dc_interrupt_smtp_idle(dc_context_t* context)
 
 	pthread_mutex_unlock(&context->smtpidle_condmutex);
 }
+
+
+
+/**
+ * This function can be called whenever there is a hint
+ * that the network is available again.
+ * The library will try to send pending messages out.
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @return None.
+ */
+void dc_maybe_network(dc_context_t* context)
+{
+	// TODO: make sure, sending is tried independingly of retry-count or timeouts.
+	// if the first messages comes through, the others should be retried as well.
+
+	dc_interrupt_smtp_idle(context);
+	dc_interrupt_imap_idle(context);
+}

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -412,8 +412,8 @@ static void dc_suspend_smtp_thread(dc_context_t* context, int suspend)
 
 static time_t get_backoff_time_offset(int c_tries)
 {
-	#define MULTIPLY 5
-	#define JOB_RETRIES 16 // results in max. 17 hours
+	#define MULTIPLY 60
+	#define JOB_RETRIES 16 // results in ~3 weeks for the last backoff timespan
 
 	int N = (int)pow((double)2, c_tries) - 1;
 

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -412,7 +412,7 @@ static void dc_suspend_smtp_thread(dc_context_t* context, int suspend)
 
 static time_t get_backoff_time_offset(int c_tries)
 {
-	#define MULTIPLY 5.0
+	#define MULTIPLY 5
 	#define JOB_RETRIES 16 // results in max. 17 hours
 
 	int N = (int)pow((double)2, c_tries) - 1;

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -46,6 +46,9 @@ typedef struct dc_job_t
 	uint32_t    job_id;
 	int         action;
 	uint32_t    foreign_id;
+	time_t      desired_timestamp;
+	time_t      added_timestamp;
+	int         tries;
 	dc_param_t* param;
 
 	int         try_again;

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -30,12 +30,6 @@ extern "C" {
 #define DC_SMTP_TIMEOUT_SEC       10
 
 
-// this is the timeout after which dc_perform_smtp_idle() returns at latest.
-// this timeout should not be too large as this might be the only option to perform
-// jobs that failed on the first execution.
-#define DC_SMTP_IDLE_SEC          60
-
-
 /**
  * Library-internal.
  */

--- a/src/dc_param.h
+++ b/src/dc_param.h
@@ -40,7 +40,6 @@ typedef struct dc_param_t
 
 #define DC_PARAM_SERVER_FOLDER     'Z'  /* for jobs */
 #define DC_PARAM_SERVER_UID        'z'  /* for jobs */
-#define DC_PARAM_TIMES             't'  /* for jobs: times a job was tried */
 
 #define DC_PARAM_UNPROMOTED        'U'  /* for groups */
 #define DC_PARAM_PROFILE_IMAGE     'i'  /* for groups and contacts */

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -484,6 +484,15 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			}
 		#undef NEW_DB_VERSION
 
+		#define NEW_DB_VERSION 47
+			if (dbversion < NEW_DB_VERSION)
+			{
+				dc_sqlite3_execute(sql, "ALTER TABLE jobs ADD COLUMN tries INTEGER DEFAULT 0;");
+
+				dbversion = NEW_DB_VERSION;
+				dc_sqlite3_set_config_int(sql, "dbversion", NEW_DB_VERSION);
+			}
+		#undef NEW_DB_VERSION
 
 		// (2) updates that require high-level objects
 		// (the structure is complete now and all objects are usable)

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -227,6 +227,8 @@ void            dc_perform_smtp_jobs         (dc_context_t*);
 void            dc_perform_smtp_idle         (dc_context_t*);
 void            dc_interrupt_smtp_idle       (dc_context_t*);
 
+void            dc_maybe_network             (dc_context_t*);
+
 
 // handle chatlists
 #define         DC_GCL_ARCHIVED_ONLY         0x01

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,7 +39,7 @@ lib_src = [
   'dc_tools.c',
 ]
 
-lib_deps = [pthreads, zlib, openssl, sasl, sqlite, etpan, netpgp]
+lib_deps = [pthreads, zlib, openssl, sasl, sqlite, etpan, netpgp, math]
 lib_inc = include_directories('.')
 lib = library(
   'deltachat', lib_src,


### PR DESCRIPTION
make the retries on failures more reliable, see https://en.wikipedia.org/wiki/Exponential_backoff.

- the calculation of the backoff times is done in [get_backoff_time_offset()](https://github.com/deltachat/deltachat-core/pull/417/files#diff-3f291e506d02f02b7f7e2e9ba43234b4R413) which is based on the [playground-python-snippet](https://github.com/deltachat/playground/blob/master/expbackoff/compute.py)
- we use a MULTIPLY of 5 which results in random retries in the following intervals in seconds: [0..5] [0..15] [0..35] [0..75] [0..155] [0..315] [0..635] [0..1275] [0..2555] [0..5115] [0..10235] [0..20475] [0..40955] [0..81915] [0..163835] (the last one is about max. 2 days, we stop after 16 retries)
- we introduce a new function (o/ @ralphtheninja) called [dc_maybe_network()](https://github.com/deltachat/deltachat-core/pull/417/files#diff-3f291e506d02f02b7f7e2e9ba43234b4R992) which which can be called by the ui when there are reasons to believe network is available again. after this function is called, the core tries to get jobs done at once and bypasses the calculated time. on failure, however, the times are not reset but kept.  
it's fine if the ui _never_ calls this function, then everything is handled by the backoff times, which, however, will take more time

@hpk42 the calculated time-offsets are added to the starting time of the job currently. as this offset can be 0 at any interval, the new calculated started time may be in the _past_. in this case, the job is retried at once. this is technically no problem, however, i am not sure if this matches the initial idea. want just to mention this :)

btw: no idea why travis complains on this pr.

closes #265