### PR TITLE
make dc_get_fresh_msgs() more reliable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
-  if: env(DOCS) IS present
   script: bash $TRAVIS_BUILD_DIR/.scripts/deploy.sh
   on:
     all_branches: true
+    condition: $DOCS

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
+  if: env(DOCS) IS present
   script: bash $TRAVIS_BUILD_DIR/.scripts/deploy.sh
   on:
     all_branches: true


### PR DESCRIPTION
- do not return special chat_ids to the list (this was not notices in the old telegram-ui as the list was compared against the messages arrived through DC_EVENT_INCOMING_MSG, however, what should not be necessary)
- do not return NULL on errors, instead, return the empty list as also done for other functions
- add a bit more of documentation