### PR TITLE
remove DC_EVENT_IS_OFFLINE

### DIFF
--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -426,13 +426,6 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 
 	PROGRESS(0)
 
-	if (context->cb(context, DC_EVENT_IS_OFFLINE, 0, 0)!=0) {
-		dc_log_error(context, DC_ERROR_NO_NETWORK, NULL);
-		goto cleanup;
-	}
-
-	PROGRESS(100)
-
 	/* 1.  Load the parameters and check email-address and password
 	 **************************************************************************/
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -89,10 +89,10 @@ struct _dc_context
 };
 
 void            dc_log_error         (dc_context_t*, int code, const char* msg, ...);
-void            dc_log_error_if      (int* condition, dc_context_t*, int code, const char* msg, ...);
 void            dc_log_warning       (dc_context_t*, int code, const char* msg, ...);
 void            dc_log_info          (dc_context_t*, int code, const char* msg, ...);
-void            dc_log_event         (dc_context_t* context, int event_code, int code, const char* msg, ...);
+void            dc_log_event         (dc_context_t*, int event_code, int code, const char* msg, ...);
+void            dc_log_event_seq     (dc_context_t*, int event_code, int* sequence_start, const char* msg, ...);
 void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
 #define         DC_BAK_PREFIX                "delta-chat"

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -136,9 +136,6 @@ extern int      dc_shall_stop_ongoing;
 int             dc_alloc_ongoing     (dc_context_t*);
 void            dc_free_ongoing      (dc_context_t*);
 
-#define         dc_is_online(m)             ((m)->cb((m), DC_EVENT_IS_OFFLINE, 0, 0)==0)
-#define         dc_is_offline(m)            ((m)->cb((m), DC_EVENT_IS_OFFLINE, 0, 0)!=0)
-
 
 /* library private: secure-join */
 #define         DC_HANDSHAKE_CONTINUE_NORMAL_PROCESSING 0x01

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -712,11 +712,6 @@ static int setup_handle_if_needed(dc_imap_t* imap)
 		goto cleanup;
     }
 
-	if (imap->context->cb(imap->context, DC_EVENT_IS_OFFLINE, 0, 0)!=0) {
-		dc_log_error_if(&imap->log_connect_errors, imap->context, DC_ERROR_NO_NETWORK, NULL);
-		goto cleanup;
-	}
-
 	imap->etpan = mailimap_new(0, NULL);
 
 	mailimap_set_timeout(imap->etpan, DC_IMAP_TIMEOUT_SEC);

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -720,7 +720,8 @@ static int setup_handle_if_needed(dc_imap_t* imap)
 	{
 		r = mailimap_socket_connect(imap->etpan, imap->imap_server, imap->imap_port);
 		if (is_error(imap, r)) {
-			dc_log_error_if(&imap->log_connect_errors, imap->context, 0, "Could not connect to IMAP-server %s:%i. (Error #%i)", imap->imap_server, (int)imap->imap_port, (int)r);
+			dc_log_event_seq(imap->context, DC_EVENT_ERROR_NETWORK, &imap->log_connect_errors,
+				"Could not connect to IMAP-server %s:%i. (Error #%i)", imap->imap_server, (int)imap->imap_port, (int)r);
 			goto cleanup;
 		}
 
@@ -728,7 +729,8 @@ static int setup_handle_if_needed(dc_imap_t* imap)
 		{
 			r = mailimap_socket_starttls(imap->etpan);
 			if (is_error(imap, r)) {
-				dc_log_error_if(&imap->log_connect_errors, imap->context, 0, "Could not connect to IMAP-server %s:%i using STARTTLS. (Error #%i)", imap->imap_server, (int)imap->imap_port, (int)r);
+				dc_log_event_seq(imap->context, DC_EVENT_ERROR_NETWORK, &imap->log_connect_errors,
+					"Could not connect to IMAP-server %s:%i using STARTTLS. (Error #%i)", imap->imap_server, (int)imap->imap_port, (int)r);
 				goto cleanup;
 			}
 			dc_log_info(imap->context, 0, "IMAP-server %s:%i STARTTLS-connected.", imap->imap_server, (int)imap->imap_port);
@@ -742,7 +744,8 @@ static int setup_handle_if_needed(dc_imap_t* imap)
 	{
 		r = mailimap_ssl_connect(imap->etpan, imap->imap_server, imap->imap_port);
 		if (is_error(imap, r)) {
-			dc_log_error_if(&imap->log_connect_errors, imap->context, 0, "Could not connect to IMAP-server %s:%i using SSL. (Error #%i)", imap->imap_server, (int)imap->imap_port, (int)r);
+			dc_log_event_seq(imap->context, DC_EVENT_ERROR_NETWORK, &imap->log_connect_errors,
+				"Could not connect to IMAP-server %s:%i using SSL. (Error #%i)", imap->imap_server, (int)imap->imap_port, (int)r);
 			goto cleanup;
 		}
 		dc_log_info(imap->context, 0, "IMAP-server %s:%i SSL-connected.", imap->imap_server, (int)imap->imap_port);
@@ -768,7 +771,8 @@ static int setup_handle_if_needed(dc_imap_t* imap)
 
 	if (is_error(imap, r)) {
 		char* msg = get_error_msg(imap, "Cannot login", r);
-		dc_log_error_if(&imap->log_connect_errors, imap->context, 0, "%s", msg);
+		dc_log_event_seq(imap->context, DC_EVENT_ERROR_NETWORK, &imap->log_connect_errors,
+			"%s", msg);
 		free(msg);
 		goto cleanup;
 	}

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -732,8 +732,7 @@ void dc_perform_imap_fetch(dc_context_t* context)
 
 	dc_imap_fetch(context->imap);
 
-	if (context->imap->should_reconnect
-	 && context->cb(context, DC_EVENT_IS_OFFLINE, 0, 0)==0)
+	if (context->imap->should_reconnect)
 	{
 		dc_log_info(context, 0, "IMAP-fetch aborted, starting over...");
 		dc_imap_fetch(context->imap);

--- a/src/dc_log.c
+++ b/src/dc_log.c
@@ -95,6 +95,7 @@ void dc_log_error_if(int* condition, dc_context_t* context, int code, const char
 		if (*condition) {
 			/* pop-up error, if we're offline, force a "not connected" error (the function is not used for other cases) */
 			if (context->cb(context, DC_EVENT_IS_OFFLINE, 0, 0)!=0) {
+				log_vprintf(context, DC_EVENT_WARNING, code, msg, va);
 				log_vprintf(context, DC_EVENT_ERROR, DC_ERROR_NO_NETWORK, NULL, va);
 			}
 			else {

--- a/src/dc_log.c
+++ b/src/dc_log.c
@@ -20,14 +20,9 @@ static void log_vprintf(dc_context_t* context, int event, int code, const char* 
 		return;
 	}
 
-	/* format message from variable parameters or translate very comming errors */
-	if (code==DC_ERROR_SELF_NOT_IN_GROUP)
+	if (code==DC_ERROR_SELF_NOT_IN_GROUP) // TODO: this should also be better a separate event
 	{
 		msg = dc_stock_str(context, DC_STR_SELFNOTINGRP);
-	}
-	else if (code==DC_ERROR_NO_NETWORK)
-	{
-		msg = dc_stock_str(context, DC_STR_NONETWORK);
 	}
 	else if (msg_format)
 	{
@@ -36,15 +31,11 @@ static void log_vprintf(dc_context_t* context, int event, int code, const char* 
 		vsnprintf(tempbuf, BUFSIZE, msg_format, va);
 		msg = dc_strdup(tempbuf);
 	}
-
-	/* if we have still no message, create one based upon  the code */
-	if (msg==NULL) {
-		     if (event==DC_EVENT_INFO)    { msg = dc_mprintf("Info: %i",    (int)code); }
-		else if (event==DC_EVENT_WARNING) { msg = dc_mprintf("Warning: %i", (int)code); }
-		else                                 { msg = dc_mprintf("Error: %i",   (int)code); }
+	else
+	{
+		msg = dc_mprintf("event #%i", (int)event);
 	}
 
-	/* finally, log */
 	context->cb(context, event, (uintptr_t)code, (uintptr_t)msg);
 }
 
@@ -66,6 +57,23 @@ void dc_log_event(dc_context_t* context, int event_code, int code, const char* m
 }
 
 
+void dc_log_event_seq(dc_context_t* context, int event_code, int* sequence_start, const char* msg, ...)
+{
+	// logs an event and add a sequence-start-indicator to data1;
+	// once logged, the sequence-start-indicator is set to 0 so that subseqent events are marked as such.
+	// the indicator is useful for the ui eg. to not raise every connection-retry arror to the user.
+	if (context==NULL || sequence_start==NULL || context->magic!=DC_CONTEXT_MAGIC) {
+		return;
+	}
+
+	va_list va;
+	va_start(va, msg);
+		log_vprintf(context, event_code, *sequence_start, NULL, va);
+		*sequence_start = 0;
+	va_end(va);
+}
+
+
 void dc_log_warning(dc_context_t* context, int code, const char* msg, ...)
 {
 	va_list va;
@@ -80,33 +88,6 @@ void dc_log_error(dc_context_t* context, int code, const char* msg, ...)
 	va_list va;
 	va_start(va, msg);
 		log_vprintf(context, DC_EVENT_ERROR, code, msg, va);
-	va_end(va);
-}
-
-
-void dc_log_error_if(int* condition, dc_context_t* context, int code, const char* msg, ...)
-{
-	if (condition==NULL || context==NULL || context->magic!=DC_CONTEXT_MAGIC) {
-		return;
-	}
-
-	va_list va;
-	va_start(va, msg);
-		if (*condition) {
-			/* pop-up error, if we're offline, force a "not connected" error (the function is not used for other cases) */
-			if (context->cb(context, DC_EVENT_IS_OFFLINE, 0, 0)!=0) {
-				log_vprintf(context, DC_EVENT_WARNING, code, msg, va);
-				log_vprintf(context, DC_EVENT_ERROR, DC_ERROR_NO_NETWORK, NULL, va);
-			}
-			else {
-				log_vprintf(context, DC_EVENT_ERROR, code, msg, va);
-			}
-			*condition = 0;
-		}
-		else {
-			/* log a warning only (eg. for subsequent connection errors) */
-			log_vprintf(context, DC_EVENT_WARNING, code, msg, va);
-		}
 	va_end(va);
 }
 

--- a/src/dc_securejoin.c
+++ b/src/dc_securejoin.c
@@ -438,13 +438,6 @@ uint32_t dc_join_securejoin(dc_context_t* context, const char* qr)
 
 	CHECK_EXIT
 
-	if (context->cb(context, DC_EVENT_IS_OFFLINE, 0, 0)!=0) {
-		dc_log_error(context, DC_ERROR_NO_NETWORK, NULL);
-		goto cleanup;
-	}
-
-	CHECK_EXIT
-
 	join_vg = (qr_scan->state==DC_QR_ASK_VERIFYGROUP);
 
 	context->bobs_status = 0;

--- a/src/dc_smtp.c
+++ b/src/dc_smtp.c
@@ -82,11 +82,6 @@ int dc_smtp_connect(dc_smtp_t* smtp, const dc_loginparam_t* lp)
 		return 0;
 	}
 
-	if (smtp->context->cb(smtp->context, DC_EVENT_IS_OFFLINE, 0, 0)!=0) {
-		dc_log_error_if(&smtp->log_connect_errors, smtp->context, DC_ERROR_NO_NETWORK, NULL);
-		goto cleanup;
-	}
-
 	if (smtp->etpan) {
 		dc_log_warning(smtp->context, 0, "SMTP already connected.");
 		success = 1; /* otherwise, the handle would get deleted */

--- a/src/dc_smtp.c
+++ b/src/dc_smtp.c
@@ -89,7 +89,8 @@ int dc_smtp_connect(dc_smtp_t* smtp, const dc_loginparam_t* lp)
 	}
 
 	if (lp->addr==NULL || lp->send_server==NULL || lp->send_port==0) {
-		dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP bad parameters.");
+		dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+			"SMTP bad parameters.");
 		goto cleanup;
 	}
 
@@ -111,14 +112,18 @@ int dc_smtp_connect(dc_smtp_t* smtp, const dc_loginparam_t* lp)
 	if (lp->server_flags&(DC_LP_SMTP_SOCKET_STARTTLS|DC_LP_SMTP_SOCKET_PLAIN))
 	{
 		if ((r=mailsmtp_socket_connect(smtp->etpan, lp->send_server, lp->send_port)) != MAILSMTP_NO_ERROR) {
-			dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP-Socket connection to %s:%i failed (%s)", lp->send_server, (int)lp->send_port, mailsmtp_strerror(r));
+			dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+				"SMTP-Socket connection to %s:%i failed (%s)",
+				lp->send_server, (int)lp->send_port, mailsmtp_strerror(r));
 			goto cleanup;
 		}
 	}
 	else
 	{
 		if ((r=mailsmtp_ssl_connect(smtp->etpan, lp->send_server, lp->send_port)) != MAILSMTP_NO_ERROR) {
-			dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP-SSL connection to %s:%i failed (%s)", lp->send_server, (int)lp->send_port, mailsmtp_strerror(r));
+			dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+				"SMTP-SSL connection to %s:%i failed (%s)",
+				lp->send_server, (int)lp->send_port, mailsmtp_strerror(r));
 			goto cleanup;
 		}
 	}
@@ -133,14 +138,16 @@ int dc_smtp_connect(dc_smtp_t* smtp, const dc_loginparam_t* lp)
 	}
 
 	if (r != MAILSMTP_NO_ERROR) {
-		dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP-helo failed (%s)", mailsmtp_strerror(r));
+		dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+			"SMTP-helo failed (%s)", mailsmtp_strerror(r));
 		goto cleanup;
 	}
 
 	if (lp->server_flags&DC_LP_SMTP_SOCKET_STARTTLS)
 	{
 		if ((r=mailsmtp_socket_starttls(smtp->etpan)) != MAILSMTP_NO_ERROR) {
-			dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP-STARTTLS failed (%s)", mailsmtp_strerror(r));
+			dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+				"SMTP-STARTTLS failed (%s)", mailsmtp_strerror(r));
 			goto cleanup;
 		}
 
@@ -153,7 +160,8 @@ int dc_smtp_connect(dc_smtp_t* smtp, const dc_loginparam_t* lp)
 		}
 
 		if (r != MAILSMTP_NO_ERROR) {
-			dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP-helo failed (%s)", mailsmtp_strerror(r));
+			dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+				"SMTP-helo failed (%s)", mailsmtp_strerror(r));
 			goto cleanup;
 		}
 		dc_log_info(smtp->context, 0, "SMTP-server %s:%i STARTTLS-connected.", lp->send_server, (int)lp->send_port);
@@ -188,7 +196,8 @@ int dc_smtp_connect(dc_smtp_t* smtp, const dc_loginparam_t* lp)
 			}
 			if (r != MAILSMTP_NO_ERROR)
 			{
-				dc_log_error_if(&smtp->log_connect_errors, smtp->context, 0, "SMTP-login failed for user %s (%s)", lp->send_user, mailsmtp_strerror(r));
+				dc_log_event_seq(smtp->context, DC_EVENT_ERROR_NETWORK, &smtp->log_connect_errors,
+					"SMTP-login failed for user %s (%s)", lp->send_user, mailsmtp_strerror(r));
 				goto cleanup;
 			}
 		}

--- a/src/dc_stock.c
+++ b/src/dc_stock.c
@@ -30,7 +30,6 @@ static char* default_string(int id)
 		case DC_STR_MSGDELMEMBER:          return dc_strdup("Member %1$s removed.");
 		case DC_STR_MSGGROUPLEFT:          return dc_strdup("Left group.");
 		case DC_STR_SELFNOTINGRP:          return dc_strdup("You must be a member of the group to perform this action.");
-		case DC_STR_NONETWORK:             return dc_strdup("No network available.");
 		case DC_STR_E2E_AVAILABLE:         return dc_strdup("End-to-end encryption available.");
 		case DC_STR_ENCR_TRANSP:           return dc_strdup("Transport-encryption.");
 		case DC_STR_ENCR_NONE:             return dc_strdup("No encryption.");

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -159,7 +159,7 @@ extern "C" {
  *
  * Please keep in mind, that your derived work must respect the Mozilla
  * Public License 2.0 of libdeltachat and the respective licenses of
- * the libraries libdeltachat links with. 
+ * the libraries libdeltachat links with.
  *
  * See you.
  */
@@ -802,6 +802,30 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 
 /**
+ * An action cannot be performed because there is no network available.
+ *
+ * The library will typically try over after a some time
+ * and when dc_maybe_network() is called.
+ *
+ * Network errors should be reported to users in a non-disturbing way,
+ * however, as network errors may come in a sequence,
+ * it is not useful to raise each an every error to the user.
+ * For this purpose, data1 is set to 1 if the error is probably worth reporting.
+ *
+ * Moreover, if the UI detects that the device is offline,
+ * it is probably more useful to report this to the user
+ * instread of the string from data2.
+ *
+ * @param data1 (int) 1=first/new network error, should be reported the user;
+ *     0=subsequent network error, should be logged only
+ * @param data2 (const char*) Error string, always set, never NULL.
+ *     Must not be free()'d or modified and is valid only until the callback returns.
+ * @return 0
+ */
+#define DC_EVENT_ERROR_NETWORK            401
+
+
+/**
  * Messages or chats changed.  One or more messages or chats changed for various
  * reasons in the database:
  * - Messages sent, received or removed
@@ -955,17 +979,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 // the following events are functions that should be provided by the frontends
 
-/**
- * Ask the frontend about the offline state.
- * This function may be provided by the frontend. If we already know, that we're
- * offline, eg. there is no need to try to connect and things will speed up.
- *
- * @param data1 0
- * @param data2 0
- * @return 0=online, 1=offline
- */
-#define DC_EVENT_IS_OFFLINE               2081
-
 
 /**
  * Requeste a localized string from the frontend.
@@ -1002,6 +1015,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  */
 
 #define DC_EVENT_FILE_COPIED         2055 // deprecated
+#define DC_EVENT_IS_OFFLINE          2081 // deprecated
 #define DC_EVENT_DATA1_IS_STRING(e)  ((e)==DC_EVENT_HTTP_GET || (e)==DC_EVENT_IMEX_FILE_WRITTEN || (e)==DC_EVENT_FILE_COPIED)
 #define DC_EVENT_DATA2_IS_STRING(e)  ((e)==DC_EVENT_INFO || (e) == DC_EVENT_WARNING || (e) == DC_EVENT_ERROR || (e) == DC_EVENT_SMTP_CONNECTED || (e) == DC_EVENT_SMTP_MESSAGE_SENT || (e) == DC_EVENT_IMAP_CONNECTED)
 #define DC_EVENT_RETURNS_INT(e)      ((e)==DC_EVENT_IS_OFFLINE)
@@ -1034,18 +1048,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  */
 #define DC_ERROR_SELF_NOT_IN_GROUP          1
 
-
-/**
- * An action cannot be performed because there is no network available.
- * Reported by #DC_EVENT_ERROR eg. after a network function fails and #DC_EVENT_IS_OFFLINE reports being offline.
- *
- * The library will typically try over when dc_perform_smtp_jobs() or dc_perform_imap_jobs() is called again by the UI -
- * eg. in a loop or if the network situation changes.
- *
- * The library tries to issue this error only once the network becomes unavailable so that the UI can
- * show this error to the user unconditionally.
- */
-#define DC_ERROR_NO_NETWORK                 2
 
 /**
  * @}
@@ -1081,7 +1083,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 #define DC_STR_MSGDELMEMBER               18
 #define DC_STR_MSGGROUPLEFT               19
 #define DC_STR_SELFNOTINGRP               21
-#define DC_STR_NONETWORK                  22
 #define DC_STR_GIF                        23
 #define DC_STR_ENCRYPTEDMSG               24
 #define DC_STR_E2E_AVAILABLE              25


### PR DESCRIPTION
this pr stops using DC_EVENT_IS_OFFLINE to decide if to connect or to retry a job.

instead, the network action is just performed and if it fails, well, we know that.

there is one remaining usage of DC_EVENT_IS_OFFLINE: _if_ an network error occurred, only the first one is reported as an error that should be shown to the user (via DC_EVENT_ERROR) - if there is not network in that moment we say just "No Network" to the user instead of sth. as "Login with password xyz" failed as the latter is probably misleading. however, the latter is still logged as a warning.

closes #426
closes https://github.com/deltachat/deltachat-android-ii/issues/127
also tackles #293 a bit