### PR TITLE
use longer IMAP-idle timeout

### DIFF
--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -634,9 +634,9 @@ void dc_imap_idle(dc_imap_t* imap)
 		}
 
 		// most servers do not allow more than ~28 minutes; stay clearly below that.
-		// a good value is 23 minutes.  however, as we do all imap in the same thread,
-		// we use a shorter delay to let failed jobs run again from time to time.
-		#define IDLE_DELAY_SECONDS (1*60)
+		// a good value that is also used by other MUAs is 23 minutes.
+		// if needed, the ui can call dc_imap_interrupt_idle() to trigger a reconnect.
+		#define IDLE_DELAY_SECONDS (23*60)
 
 		r = mailstream_wait_idle(imap->etpan->imap_stream, IDLE_DELAY_SECONDS);
 		r2 = mailimap_idle_done(imap->etpan);


### PR DESCRIPTION
due to exponential backoff and dc_maybe_network(), we can process jobs at any time now, very short IMAP-timeouts are no longer needed (the 1 minute came from the need to process jobs in a very simple way); reset to 23 minutes as before imap/smtp-thrad-split

in addition to that, the UI can call dc_interrupt_imap_idle() at any time (to protect against  NAT Gateway timeout? not sure, but needed eg. in Android for any reason, cmp. https://www.isode.com/whitepapers/imap-idle.html)