### PR TITLE
simplify events

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -1630,7 +1630,8 @@ int dc_set_chat_name(dc_context_t* context, uint32_t chat_id, const char* new_na
 	}
 
 	if (!IS_SELF_IN_GROUP) {
-		dc_log_error(context, DC_ERROR_SELF_NOT_IN_GROUP, NULL);
+		dc_log_event(context, DC_EVENT_ERROR_SELF_NOT_IN_GROUP, 0,
+		             "Cannot set chat name; self not in group");
 		goto cleanup; /* we shoud respect this - whatever we send to the group, it gets discarded anyway! */
 	}
 
@@ -1694,7 +1695,8 @@ int dc_set_chat_profile_image(dc_context_t* context, uint32_t chat_id, const cha
 	}
 
 	if (!IS_SELF_IN_GROUP) {
-		dc_log_error(context, DC_ERROR_SELF_NOT_IN_GROUP, NULL);
+		dc_log_event(context, DC_EVENT_ERROR_SELF_NOT_IN_GROUP, 0,
+		             "Cannot set chat profile image; self not in group.");
 		goto cleanup; /* we shoud respect this - whatever we send to the group, it gets discarded anyway! */
 	}
 
@@ -1798,7 +1800,8 @@ int dc_add_contact_to_chat_ex(dc_context_t* context, uint32_t chat_id, uint32_t 
 	}
 
 	if (!IS_SELF_IN_GROUP) {
-		dc_log_error(context, DC_ERROR_SELF_NOT_IN_GROUP, NULL);
+		dc_log_event(context, DC_EVENT_ERROR_SELF_NOT_IN_GROUP, 0,
+		             "Cannot add contact to group; self not in group.");
 		goto cleanup; /* we shoud respect this - whatever we send to the group, it gets discarded anyway! */
 	}
 
@@ -1914,7 +1917,8 @@ int dc_remove_contact_from_chat(dc_context_t* context, uint32_t chat_id, uint32_
 	}
 
 	if (!IS_SELF_IN_GROUP) {
-		dc_log_error(context, DC_ERROR_SELF_NOT_IN_GROUP, NULL);
+		dc_log_event(context, DC_EVENT_ERROR_SELF_NOT_IN_GROUP, 0,
+		             "Cannot remove contact from chat; self not in group.");
 		goto cleanup; /* we shoud respect this - whatever we send to the group, it gets discarded anyway! */
 	}
 
@@ -2053,7 +2057,8 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 	}
 
 	if (DC_CHAT_TYPE_IS_MULTI(chat->type) && !dc_is_contact_in_chat(context, chat->id, DC_CONTACT_ID_SELF)) {
-		dc_log_error(context, DC_ERROR_SELF_NOT_IN_GROUP, NULL);
+		dc_log_event(context, DC_EVENT_ERROR_SELF_NOT_IN_GROUP, 0,
+		             "Cannot send message; self not in group.");
 		goto cleanup;
 	}
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -88,11 +88,12 @@ struct _dc_context
 	int              shall_stop_ongoing;
 };
 
-void            dc_log_error         (dc_context_t*, int code, const char* msg, ...);
-void            dc_log_warning       (dc_context_t*, int code, const char* msg, ...);
-void            dc_log_info          (dc_context_t*, int code, const char* msg, ...);
-void            dc_log_event         (dc_context_t*, int event_code, int code, const char* msg, ...);
+void            dc_log_event         (dc_context_t*, int event_code, int data1, const char* msg, ...);
 void            dc_log_event_seq     (dc_context_t*, int event_code, int* sequence_start, const char* msg, ...);
+void            dc_log_error         (dc_context_t*, int data1, const char* msg, ...);
+void            dc_log_warning       (dc_context_t*, int data1, const char* msg, ...);
+void            dc_log_info          (dc_context_t*, int data1, const char* msg, ...);
+
 void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
 #define         DC_BAK_PREFIX                "delta-chat"

--- a/src/dc_log.c
+++ b/src/dc_log.c
@@ -12,7 +12,7 @@ are usually logged by dc_log_warning(). */
 #include "dc_context.h"
 
 
-static void log_vprintf(dc_context_t* context, int event, int code, const char* msg_format, va_list va)
+static void log_vprintf(dc_context_t* context, int event, int data1, const char* msg_format, va_list va)
 {
 	char* msg = NULL;
 
@@ -32,23 +32,23 @@ static void log_vprintf(dc_context_t* context, int event, int code, const char* 
 		msg = dc_mprintf("event #%i", (int)event);
 	}
 
-	context->cb(context, event, (uintptr_t)code, (uintptr_t)msg);
+	context->cb(context, event, (uintptr_t)data1, (uintptr_t)msg);
 }
 
 
-void dc_log_info(dc_context_t* context, int code, const char* msg, ...)
+void dc_log_info(dc_context_t* context, int data1, const char* msg, ...)
 {
 	va_list va;
 	va_start(va, msg); /* va_start() expects the last non-variable argument as the second parameter */
-		log_vprintf(context, DC_EVENT_INFO, code, msg, va);
+		log_vprintf(context, DC_EVENT_INFO, data1, msg, va);
 	va_end(va);
 }
 
-void dc_log_event(dc_context_t* context, int event_code, int code, const char* msg, ...)
+void dc_log_event(dc_context_t* context, int event_code, int data1, const char* msg, ...)
 {
 	va_list va;
 	va_start(va, msg); /* va_start() expects the last non-variable argument as the second parameter */
-		log_vprintf(context, event_code, code, msg, va);
+		log_vprintf(context, event_code, data1, msg, va);
 	va_end(va);
 }
 
@@ -70,21 +70,19 @@ void dc_log_event_seq(dc_context_t* context, int event_code, int* sequence_start
 }
 
 
-void dc_log_warning(dc_context_t* context, int code, const char* msg, ...)
+void dc_log_warning(dc_context_t* context, int data1, const char* msg, ...)
 {
 	va_list va;
 	va_start(va, msg); /* va_start() expects the last non-variable argument as the second parameter */
-		log_vprintf(context, DC_EVENT_WARNING, code, msg, va);
+		log_vprintf(context, DC_EVENT_WARNING, data1, msg, va);
 	va_end(va);
 }
 
 
-void dc_log_error(dc_context_t* context, int code, const char* msg, ...)
+void dc_log_error(dc_context_t* context, int data1, const char* msg, ...)
 {
 	va_list va;
 	va_start(va, msg);
-		log_vprintf(context, DC_EVENT_ERROR, code, msg, va);
+		log_vprintf(context, DC_EVENT_ERROR, data1, msg, va);
 	va_end(va);
 }
-
-

--- a/src/dc_log.c
+++ b/src/dc_log.c
@@ -20,11 +20,7 @@ static void log_vprintf(dc_context_t* context, int event, int code, const char* 
 		return;
 	}
 
-	if (code==DC_ERROR_SELF_NOT_IN_GROUP) // TODO: this should also be better a separate event
-	{
-		msg = dc_stock_str(context, DC_STR_SELFNOTINGRP);
-	}
-	else if (msg_format)
+	if (msg_format)
 	{
 		#define BUFSIZE 1024
 		char tempbuf[BUFSIZE+1];

--- a/src/dc_stock.c
+++ b/src/dc_stock.c
@@ -29,7 +29,6 @@ static char* default_string(int id)
 		case DC_STR_MSGADDMEMBER:          return dc_strdup("Member %1$s added.");
 		case DC_STR_MSGDELMEMBER:          return dc_strdup("Member %1$s removed.");
 		case DC_STR_MSGGROUPLEFT:          return dc_strdup("Left group.");
-		case DC_STR_SELFNOTINGRP:          return dc_strdup("You must be a member of the group to perform this action.");
 		case DC_STR_E2E_AVAILABLE:         return dc_strdup("End-to-end encryption available.");
 		case DC_STR_ENCR_TRANSP:           return dc_strdup("Transport-encryption.");
 		case DC_STR_ENCR_NONE:             return dc_strdup("No encryption.");

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -1035,7 +1035,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 #define DC_ERROR_SELF_NOT_IN_GROUP   1    // deprecated
 #define DC_STR_SELFNOTINGRP          21   // deprecated
 #define DC_EVENT_DATA1_IS_STRING(e)  ((e)==DC_EVENT_HTTP_GET || (e)==DC_EVENT_IMEX_FILE_WRITTEN || (e)==DC_EVENT_FILE_COPIED)
-#define DC_EVENT_DATA2_IS_STRING(e)  ((e)==DC_EVENT_INFO || (e) == DC_EVENT_WARNING || (e) == DC_EVENT_ERROR || (e) == DC_EVENT_SMTP_CONNECTED || (e) == DC_EVENT_SMTP_MESSAGE_SENT || (e) == DC_EVENT_IMAP_CONNECTED)
+#define DC_EVENT_DATA2_IS_STRING(e)  ((e)>=100 && (e)<=499)
 #define DC_EVENT_RETURNS_INT(e)      ((e)==DC_EVENT_IS_OFFLINE)
 #define DC_EVENT_RETURNS_STRING(e)   ((e)==DC_EVENT_GET_STRING || (e)==DC_EVENT_HTTP_GET)
 

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -792,7 +792,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  * failed (returned false). It should be sufficient to report only the _last_ error
  * in a messasge box then.
  *
- * @param data1 (int) Error code, see @ref DC_ERROR for a list of constants.
+ * @param data1 0
  * @param data2 (const char*) Error string, always set, never NULL. Frequent error strings are
  *     localized using #DC_EVENT_GET_STRING, however, most error strings will be in english language.
  *     Must not be free()'d or modified and is valid only until the callback returns.
@@ -1032,36 +1032,13 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 #define DC_EVENT_FILE_COPIED         2055 // deprecated
 #define DC_EVENT_IS_OFFLINE          2081 // deprecated
+#define DC_ERROR_SEE_STRING          0    // deprecated
 #define DC_ERROR_SELF_NOT_IN_GROUP   1    // deprecated
 #define DC_STR_SELFNOTINGRP          21   // deprecated
 #define DC_EVENT_DATA1_IS_STRING(e)  ((e)==DC_EVENT_HTTP_GET || (e)==DC_EVENT_IMEX_FILE_WRITTEN || (e)==DC_EVENT_FILE_COPIED)
 #define DC_EVENT_DATA2_IS_STRING(e)  ((e)>=100 && (e)<=499)
 #define DC_EVENT_RETURNS_INT(e)      ((e)==DC_EVENT_IS_OFFLINE)
 #define DC_EVENT_RETURNS_STRING(e)   ((e)==DC_EVENT_GET_STRING || (e)==DC_EVENT_HTTP_GET)
-
-
-/**
- * @defgroup DC_ERROR DC_ERROR
- *
- * These constants are used as error in the event
- * #DC_EVENT_ERROR and reported to the callback given to
- * dc_context_new().
- *
- * @addtogroup DC_ERROR
- * @{
- */
-
-/**
- * Unclassified error.
- * Reported by #DC_EVENT_ERROR eg. for forwarding errors from other instances.
- * Details about the error can be found as a string in data2 that should be shown to the user by the UI.
- */
-#define DC_ERROR_SEE_STRING                 0
-
-
-/**
- * @}
- */
 
 
 /*

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -826,6 +826,22 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 
 /**
+ * An action cannot be performed because the user is not in the group.
+ * Reported eg. after a call to
+ * dc_set_chat_name(), dc_set_chat_profile_image(),
+ * dc_add_contact_to_chat(), dc_remove_contact_from_chat(),
+ * dc_send_text_msg() or another sending function.
+ *
+ * @param data1 0
+ * @param data2 (const char*) Info string in english language.
+ *     Must not be free()'d or modified
+ *     and is valid only until the callback returns.
+ * @return 0
+ */
+#define DC_EVENT_ERROR_SELF_NOT_IN_GROUP  410
+
+
+/**
  * Messages or chats changed.  One or more messages or chats changed for various
  * reasons in the database:
  * - Messages sent, received or removed
@@ -1016,6 +1032,8 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 #define DC_EVENT_FILE_COPIED         2055 // deprecated
 #define DC_EVENT_IS_OFFLINE          2081 // deprecated
+#define DC_ERROR_SELF_NOT_IN_GROUP   1    // deprecated
+#define DC_STR_SELFNOTINGRP          21   // deprecated
 #define DC_EVENT_DATA1_IS_STRING(e)  ((e)==DC_EVENT_HTTP_GET || (e)==DC_EVENT_IMEX_FILE_WRITTEN || (e)==DC_EVENT_FILE_COPIED)
 #define DC_EVENT_DATA2_IS_STRING(e)  ((e)==DC_EVENT_INFO || (e) == DC_EVENT_WARNING || (e) == DC_EVENT_ERROR || (e) == DC_EVENT_SMTP_CONNECTED || (e) == DC_EVENT_SMTP_MESSAGE_SENT || (e) == DC_EVENT_IMAP_CONNECTED)
 #define DC_EVENT_RETURNS_INT(e)      ((e)==DC_EVENT_IS_OFFLINE)
@@ -1039,14 +1057,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  * Details about the error can be found as a string in data2 that should be shown to the user by the UI.
  */
 #define DC_ERROR_SEE_STRING                 0
-
-
-/**
- * The action cannot be performed because the user is not in the group.
- * Reported by #DC_EVENT_ERROR eg. after a call to dc_set_chat_name(), dc_set_chat_profile_image(),
- * dc_add_contact_to_chat(), dc_remove_contact_from_chat(), dc_send_text_msg() or another sending function.
- */
-#define DC_ERROR_SELF_NOT_IN_GROUP          1
 
 
 /**
@@ -1082,7 +1092,6 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 #define DC_STR_MSGADDMEMBER               17
 #define DC_STR_MSGDELMEMBER               18
 #define DC_STR_MSGGROUPLEFT               19
-#define DC_STR_SELFNOTINGRP               21
 #define DC_STR_GIF                        23
 #define DC_STR_ENCRYPTEDMSG               24
 #define DC_STR_E2E_AVAILABLE              25


### PR DESCRIPTION
- remove data1 parameter from DC_EVENT_ERROR which is now in sync with DC_EVENT_WARNING|INFO. this allows easier conversion to specific events.
- turn DC_EVENT_ERROR(SELF_NOT_IN_GROUP) into DC_EVENT_ERROR_SELF_NOT_IN_GROUP(msg)
- dc_log_error(msg) is now simply a shortcut for  dc_log_event(DC_EVENT_ERROR, msg); same for dc_log_info|warning()

theoretically, we can remove the data1 parameter from dc_log_event|info|warning|error(), it is unused and always 0 is passed.  
however, not sure if we use it for different purposes (maybe translation-string-id?), so, instead of changing thousand lines or so, i suggest to wait and see for now :)

tackles #293 