### PR TITLE
print new events

### DIFF
--- a/cmdline/main.c
+++ b/cmdline/main.c
@@ -38,12 +38,32 @@ static uintptr_t receive_event(dc_context_t* context, int event, uintptr_t data1
 			}
 			break;
 
+		case DC_EVENT_SMTP_CONNECTED:
+			printf("[DC_EVENT_SMTP_CONNECTED] %s\n", (char*)data2);
+			break;
+
+		case DC_EVENT_IMAP_CONNECTED:
+			printf("[DC_EVENT_IMAP_CONNECTED] %s\n", (char*)data2);
+			break;
+
+		case DC_EVENT_SMTP_MESSAGE_SENT:
+			printf("[DC_EVENT_SMTP_MESSAGE_SENT] %s\n", (char*)data2);
+			break;
+
 		case DC_EVENT_WARNING:
 			printf("[Warning] %s\n", (char*)data2);
 			break;
 
 		case DC_EVENT_ERROR:
-			printf(ANSI_RED "[ERROR #%i] %s" ANSI_NORMAL "\n", (int)data1, (char*)data2);
+			printf(ANSI_RED "[DC_EVENT_ERROR] %s" ANSI_NORMAL "\n", (char*)data2);
+			break;
+
+		case DC_EVENT_ERROR_NETWORK:
+			printf(ANSI_RED "[DC_EVENT_ERROR_NETWORK] first=%i, msg=%s" ANSI_NORMAL "\n", (int)data1, (char*)data2);
+			break;
+
+		case DC_EVENT_ERROR_SELF_NOT_IN_GROUP:
+			printf(ANSI_RED "[DC_EVENT_ERROR_SELF_NOT_IN_GROUP] %s" ANSI_NORMAL "\n", (char*)data2);
 			break;
 
 		case DC_EVENT_HTTP_GET:

--- a/src/dc_log.c
+++ b/src/dc_log.c
@@ -64,7 +64,7 @@ void dc_log_event_seq(dc_context_t* context, int event_code, int* sequence_start
 
 	va_list va;
 	va_start(va, msg);
-		log_vprintf(context, event_code, *sequence_start, NULL, va);
+		log_vprintf(context, event_code, *sequence_start, msg, va);
 		*sequence_start = 0;
 	va_end(va);
 }


### PR DESCRIPTION
- the detailed error string on network messages was accidentally not forwarded to DC_EVENT_ERROR_NETWORK; instead the string "event #401" was shown
- log the new events in the command line tool