### PR TITLE
 tweak get_backoff_time_offset()

### DIFF
--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -413,13 +413,13 @@ static void dc_suspend_smtp_thread(dc_context_t* context, int suspend)
 static time_t get_backoff_time_offset(int c_tries)
 {
 	#define MULTIPLY 60
-	#define JOB_RETRIES 16 // results in ~3 weeks for the last backoff timespan
+	#define JOB_RETRIES 17 // results in ~3 weeks for the last backoff timespan
 
-	int N = (int)pow((double)2, c_tries) - 1;
+	time_t N = (time_t)pow((double)2, c_tries - 1);
 
-	int r = rand() % (N+1);
+	N = N * MULTIPLY;
 
-	time_t seconds = r * MULTIPLY;
+	time_t seconds = rand() % (N+1);
 
 	if (seconds<1) {
 		seconds = 1;


### PR DESCRIPTION
tweaking/fixing  get_backoff_time_offset():

- moved the `- 1` to the exponent (probably a typo, does not make really sense outside the bracket imho) so that the first retry is within a minute (2^0  = 1)
- to keep the max. timespan, increased the number of retries by one
- move the MULTIPLY in front of the randomization; before, every first-retry was exactly either 0 or 60 seconds

note, however, that each failed try is repeated _at once_, so that closed sockets and such things are catched immediately. 

moreover, _if_ the ui knows network becomes available again, the ui may bypass the calculated times by using dc_maybe_network(). on desktop, afaik, this function is currently never called, so that sending will be always delayed by these timespans.