### PR TITLE
use '...' as the subject-fallback-text wrt memoryhole

### DIFF
--- a/src/dc_e2ee.c
+++ b/src/dc_e2ee.c
@@ -423,10 +423,8 @@ void dc_e2ee_encrypt(dc_context_t* context, const clist* recipients_addr,
 			}
 		}
 
-		char* e = dc_stock_str(context, DC_STR_ENCRYPTEDMSG); char* subject_str = dc_mprintf(DC_CHAT_PREFIX " %s", e); free(e);
-		struct mailimf_subject* subject = mailimf_subject_new(dc_encode_header_words(subject_str));
+		struct mailimf_subject* subject = mailimf_subject_new(dc_strdup("..."));
 		mailimf_fields_add(imffields_unprotected, mailimf_field_new(MAILIMF_FIELD_SUBJECT, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, subject, NULL, NULL, NULL));
-		free(subject_str);
 
 		clist_append(part_to_encrypt->mm_content_type->ct_parameters, mailmime_param_new_with_data("protected-headers", "v1"));
 


### PR DESCRIPTION
delta chat uses [memoryhole](https://github.com/autocrypt/memoryhole) to protect and encrypt the subject of messages.

the protection of the subject is done by moving the subject header to the encypted part of the message; the original subject header can be used to add a "fallback" text that is displayed by MUAs before the message is really decrypted or by MUAs that do not support memoryhole at all.

most MUAs show sth. as "Encrypted Message" as the fallback text, which, however has some drawbacks and is annoying as the recent discussions on #autocrypt shows.

some drawbacks taken from there:

- using the word "encrypted" in the visible part may confuse users, esp. if they are using autocrypt and do not really care of encryption.  
"oh great, i have an encrypted messages" might be sth. a typical user does not really think :)
- cleartext replies to encrypted messages may easily get the subject "Re: Encrypted Message"
- localization issues - getting subjects as "Titkosított üzenet" or "Зашифрованное сообщение" might users confuse even more (confuses me, btw)

an idea brought up by @azul and @hpk42 was to just use three dots as the fallback replacement:

- `...` might be known to users as "a loading indicator" or a "click for more indicator" which is not that wrong - eg. in thunderbird a click on these subjects will show the correct on (maybe after querying a password)
- no localization issues
- may result in less bad user expectations

as this is code-wise a very simple fix, i would suggest just to try it out :)