### PR TITLE
Let's build portable wheels

### DIFF
--- a/libs/netpgp/meson.build
+++ b/libs/netpgp/meson.build
@@ -1,6 +1,7 @@
 project('netpgp', 'c',
         version: '20140220',
-        license: '2-part BSD')
+        license: '2-part BSD',
+        default_options: ['c_std=gnu99'])
 
 cc = meson.get_compiler('c')
 

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
   version: '0.0.0',             # Dummy, see below.
   subproject_dir: 'libs',
   meson_version: '>=0.47.2',
+  default_options: ['c_std=gnu99'],
 )
 
 

--- a/python/README.rst
+++ b/python/README.rst
@@ -1,4 +1,4 @@
-
+=========================
 deltachat python bindings
 =========================
 
@@ -7,7 +7,10 @@ which provides imap/smtp/crypto handling as well as chat/group/messages
 handling to Android, Desktop and IO user interfaces.
 
 Install
--------
+=======
+
+You may also want to build a wheel using docker instead of manually
+building deltachat-core.  See below for this.
 
 1. First you need to `install the delta-core C-library
    <https://github.com/deltachat/deltachat-core/blob/master/README.md>`_.
@@ -34,7 +37,7 @@ You may now look at `examples <https://py.delta.chat/examples.html>`_.
 
 
 Running tests
--------------
+=============
 
 Get a checkout of the `deltachat-core github repository`_ and type::
 
@@ -57,3 +60,38 @@ And then run the tests with this live-accounts config file::
 
 .. _`deltachat-core github repository`: https://github.com/deltachat/deltachat-core
 .. _`deltachat-core`: https://github.com/deltachat/deltachat-core
+
+
+Building manylinux1 wheels
+==========================
+
+Building portable manylinux1 wheels which come with libdeltachat.so
+and all it's dependencies is easy using the provided docker tooling.
+
+You will need docker, the first builds a custom docker image.  This is
+slow initially but normally updates are cached by docker.  If no
+changes were made to the dependencies this step is not needed at all
+even, though as mentioned docker will cache the results so there's no
+harm is running it again::
+
+   $ pwd               # Make sure the current working directory is the
+   .../deltachat-core  # top of the deltachat-core project checkout.
+   $ docker build -t deltachat-wheel python/wheelbuilder/
+
+
+Now you should have an image called `dcwhl` listed if you run `docker
+images`.  This image can now be used to build both libdeltachat.so and
+the Python wheel with the bindings which bundle this::
+
+   $ docker run --rm -it -v $(pwd):/io/ deltachat-wheel /io/python/wheelbuilder/build-wheels.sh
+
+The wheels will be in ``python/wheelhouse``.
+
+
+Troubleshooting
+---------------
+
+On more recent systems running the docker image may crash.  You can
+fix this by adding ``vsyscall=emulate`` to the Linux kernel boot
+arguments commandline.  E.g. on Debian you'd add this to
+``GRUB_CMDLINE_LINUX_DEFAULT`` in ``/etc/default/grub``.

--- a/python/wheelbuilder/Dockerfile
+++ b/python/wheelbuilder/Dockerfile
@@ -1,0 +1,98 @@
+FROM quay.io/pypa/manylinux1_x86_64
+
+# Configure ld.so/ldconfig and pkg-config
+RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
+    echo /usr/local/lib >> /etc/ld.so.conf.d/local.conf
+ENV PKG_CONFIG_PATH /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
+
+# Install meson and ninja
+ENV NINJA_VERSION v1.8.2
+RUN /opt/python/cp37-cp37m/bin/pip install meson
+RUN cd /usr/bin && ln -s /opt/_internal/cpython-3.7.0/bin/meson
+RUN curl -L -O https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux.zip
+RUN unzip ninja-linux.zip && mv ninja /usr/bin/ninja
+
+# Install a recent zlib, needed by libetpan
+ENV ZLIB_VERSION 1.2.11
+RUN curl -O https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+RUN tar xzf zlib-${ZLIB_VERSION}.tar.gz
+RUN cd zlib-${ZLIB_VERSION} && ./configure
+RUN cd zlib-${ZLIB_VERSION} && make
+RUN cd zlib-${ZLIB_VERSION} && make install
+RUN ldconfig -v
+
+# Install a recent Perl, needed to install OpenSSL
+ENV PERL_VERSION 5.28.0
+RUN curl -O https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz
+RUN tar xzf perl-${PERL_VERSION}.tar.gz
+RUN cd perl-${PERL_VERSION} && ./Configure -de
+RUN cd perl-${PERL_VERSION} && make
+RUN cd perl-${PERL_VERSION} && make install
+
+# Install OpenSSL
+ENV OPENSSL_VERSION 1.1.1a
+RUN curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+RUN tar xzf openssl-${OPENSSL_VERSION}.tar.gz
+RUN cd openssl-${OPENSSL_VERSION} && \
+    ./config shared no-ssl2 no-ssl3 -fPIC --prefix=/usr/local
+RUN cd openssl-${OPENSSL_VERSION} && \
+    sed -i "s/^SHLIB_MAJOR=.*/SHLIB_MAJOR=200/" Makefile && \
+    sed -i "s/^SHLIB_MINOR=.*/SHLIB_MINOR=0.0/" Makefile && \
+    sed -i "s/^SHLIB_VERSION_NUMBER=.*/SHLIB_VERSION_NUMBER=200.0.0/" Makefile
+RUN cd openssl-${OPENSSL_VERSION} && make depend
+RUN cd openssl-${OPENSSL_VERSION} && make
+RUN cd openssl-${OPENSSL_VERSION} && make install_sw install_ssldirs
+
+RUN ldconfig -v
+
+# Install cyrus-sasl
+ENV SASL_VERSION 2.1.27
+RUN curl -O ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-${SASL_VERSION}.tar.gz
+RUN tar zxf cyrus-sasl-${SASL_VERSION}.tar.gz
+RUN cd cyrus-sasl-${SASL_VERSION} && \
+    ./configure --disable-silent-rules \
+                --disable-cmulocal \
+                --disable-sample \
+                --disable-obsolete_cram_attr \
+                --disable-obsolete_digest_attr \
+                --disable-staticdlopen \
+                --disable-java \
+                --disable-alwaystrue \
+                --enable-checkapop \
+                --enable-cram \
+                --enable-digest \
+                --enable-scram \
+                --disable-otp \
+                --disable-srp \
+                --disable-srp-setpass \
+                --disable-krb4 \
+                --disable-gssapi \
+                --disable-gss_mutexes \
+                --disable-sia \
+                --disable-auth-sasldb \
+                --disable-httpform \
+                --enable-plain \
+                --enable-anon \
+                --enable-login \
+                --disable-ntlm \
+                --disable-passdss \
+                --disable-sql \
+                --disable-ldapdb \
+                --disable-macos-framework
+RUN cd cyrus-sasl-${SASL_VERSION} && make
+RUN cd cyrus-sasl-${SASL_VERSION} && make install
+RUN ldconfig -v
+
+# Install libetpan
+ENV ETPAN_VERSION 1.9.1
+RUN curl -L -o libetpan-${ETPAN_VERSION}.tar.gz \
+    https://github.com/dinhviethoa/libetpan/archive/${ETPAN_VERSION}.tar.gz
+RUN tar xzf libetpan-${ETPAN_VERSION}.tar.gz
+RUN cd libetpan-${ETPAN_VERSION} && ./autogen.sh && \
+    ./configure --enable-ipv6 \
+                --disable-iconv --disable-db \
+                --with-openssl --with-sasl --with-zlib \
+                --without-curl --without-expat
+RUN cd libetpan-${ETPAN_VERSION} && make
+RUN cd libetpan-${ETPAN_VERSION} && make install
+RUN ldconfig -v

--- a/python/wheelbuilder/build-wheels.sh
+++ b/python/wheelbuilder/build-wheels.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e -x
+
+## Build the library
+meson /builddir /io
+pushd /builddir
+ninja
+ninja install
+ldconfig -v
+popd
+
+## Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install cffi requests attrs six pytest
+    "${PYBIN}/pip" wheel /io/python -w wheelhouse/
+done
+
+## Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair "$whl" -w /io/python/wheelhouse/
+done
+
+# Clean up the cffi wheels which end up in the wheelhouse
+rm -rf /io/python/wheelhouse/cffi*.whl
+
+## Install packages (and test)
+for PYBIN in /opt/python/*/bin/; do
+    "${PYBIN}/pip" install deltachat --no-index -f /io/python/wheelhouse
+    # (cd "$HOME"; "${PYBIN}/pytest" /io/python/tests)
+done


### PR DESCRIPTION
Because I insist it's fine to install the dependencies manually, let's do that in a docker image and allow easy building of portable wheels.  Now people should be ok with getting python bindings.  We could even start distributing them on pypi if we wanted.