### PR TITLE
display empty messages as such

### DIFF
--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -1625,7 +1625,12 @@ cleanup:
 	if (!dc_mimeparser_has_nonmeta(mimeparser) && carray_count(mimeparser->reports)==0) {
 		dc_mimepart_t* part = dc_mimepart_new();
 		part->type = DC_MSG_TEXT;
-		part->msg = dc_strdup(mimeparser->subject? mimeparser->subject : "Empty message");
+		if (mimeparser->subject && !mimeparser->is_send_by_messenger) {
+			part->msg = dc_strdup(mimeparser->subject);
+		}
+		else {
+			part->msg = dc_strdup("");
+		}
 		carray_add(mimeparser->parts, (void*)part, NULL);
 	}
 }


### PR DESCRIPTION
do not fallback to the subject for empty deltachat-messages (as the subject has no meaning for deltachat, this would result in empty messages displayed as the string `Chat:`)

closes #453 