### PR TITLE
change draft api

### DIFF
--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -262,7 +262,8 @@ uint32_t        dc_get_chat_id_by_contact_id (dc_context_t*, uint32_t contact_id
 
 uint32_t        dc_send_msg                  (dc_context_t*, uint32_t chat_id, dc_msg_t*);
 uint32_t        dc_send_text_msg             (dc_context_t*, uint32_t chat_id, const char* text_to_send);
-void            dc_set_text_draft            (dc_context_t*, uint32_t chat_id, const char*);
+void            dc_set_draft                 (dc_context_t*, uint32_t chat_id, dc_msg_t*);
+dc_msg_t*       dc_get_draft                 (dc_context_t*, uint32_t chat_id);
 
 #define         DC_GCM_ADDDAYMARKER          0x01
 dc_array_t*     dc_get_chat_msgs             (dc_context_t*, uint32_t chat_id, uint32_t flags, uint32_t marker1before);
@@ -463,8 +464,6 @@ int             dc_chat_get_type             (const dc_chat_t*);
 char*           dc_chat_get_name             (const dc_chat_t*);
 char*           dc_chat_get_subtitle         (const dc_chat_t*);
 char*           dc_chat_get_profile_image    (const dc_chat_t*);
-char*           dc_chat_get_text_draft       (const dc_chat_t*);
-time_t          dc_chat_get_draft_timestamp  (const dc_chat_t*);
 int             dc_chat_get_archived         (const dc_chat_t*);
 int             dc_chat_is_unpromoted        (const dc_chat_t*);
 int             dc_chat_is_self_talk         (const dc_chat_t*);


### PR DESCRIPTION
this pr simplifies the api to get|set draft and also makes it more powerful, see #214 

a next pr will allow to save images, voice messages and other types as draft, currently, only text drafts can be handled (as before).

another api-change for these improvements is not needed, so that it makes sense to change the api already now so that android-dev and desktop need not to work with already deprecated functions.