### PR TITLE
enhance profile-image api

### DIFF
--- a/src/dc_contact.c
+++ b/src/dc_contact.c
@@ -212,6 +212,40 @@ char* dc_contact_get_first_name(const dc_contact_t* contact)
 
 
 /**
+ * Get the contact's profile image.
+ * This is the image set by each remote user on their own
+ * using dc_set_config(context, "selfavatar", image).
+ *
+ * @memberof dc_contact_t
+ * @param chat The contact object.
+ * @return Path and file if the profile image, if any.
+ *     NULL otherwise.
+ *     Must be free()'d after usage.
+ */
+char* dc_contact_get_profile_image(const dc_contact_t* contact)
+{
+	char* selfavatar = NULL;
+	char* image_abs = NULL;
+
+	if (contact==NULL || contact->magic!=DC_CONTACT_MAGIC) {
+		goto cleanup;
+	}
+
+	if (contact->id==DC_CONTACT_ID_SELF) {
+		selfavatar = dc_get_config(contact->context, "selfavatar");
+		if (selfavatar && selfavatar[0]) {
+			image_abs = dc_strdup(selfavatar);
+		}
+	}
+	// TODO: else get image_abs from contact param
+
+cleanup:
+	free(selfavatar);
+	return image_abs;
+}
+
+
+/**
  * Check if a contact is blocked.
  *
  * To block or unblock a contact, use dc_block_contact().

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -430,6 +430,8 @@ static char* get_sys_config_str(const char* key)
  * - `selfstatus`   = Own status to display eg. in email footers, defaults to a standard text
  * - `selfavatar`   = File containing avatar. Will be copied to blob directory.
  *                    NULL to remove the avatar.
+ *                    It is planned for future versions
+ *                    to send this image together with the next messages.
  * - `e2ee_enabled` = 0=no end-to-end-encryption, 1=prefer end-to-end-encryption (default)
  * - `mdns_enabled` = 0=do not send or request read receipts,
  *                    1=send and request read receipts (default)

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -569,6 +569,7 @@ char*           dc_contact_get_name          (const dc_contact_t*);
 char*           dc_contact_get_display_name  (const dc_contact_t*);
 char*           dc_contact_get_name_n_addr   (const dc_contact_t*);
 char*           dc_contact_get_first_name    (const dc_contact_t*);
+char*           dc_contact_get_profile_image (const dc_contact_t*);
 int             dc_contact_is_blocked        (const dc_contact_t*);
 int             dc_contact_is_verified       (dc_contact_t*);
 


### PR DESCRIPTION
- `dc_chat_get_profile_image()` returns the contact image for normal chats
- `dc_contact_get_profile_image()` added; currently the own profile image is returned for the SELF-chat (can be set using `dc_set_config(context, "selfavatar", image)`.
in the future, it is planned to return also the contact images received from remote users here, see #444