### PR TITLE
improve draft handling

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -1616,7 +1616,7 @@ uint32_t dc_create_group_chat(dc_context_t* context, int verified, const char* c
 		goto cleanup;
 	}
 
-	if (dc_add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF)) {
+	if (!dc_add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF)) {
 		goto cleanup;
 	}
 

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -71,11 +71,6 @@ void dc_chat_empty(dc_chat_t* chat)
 	free(chat->name);
 	chat->name = NULL;
 
-	chat->draft_timestamp = 0;
-
-	free(chat->draft_text);
-	chat->draft_text = NULL;
-
 	chat->type = DC_CHAT_TYPE_UNDEFINED;
 	chat->id   = 0;
 
@@ -368,7 +363,6 @@ int dc_chat_update_param(dc_chat_t* chat)
 static int set_from_stmt(dc_chat_t* chat, sqlite3_stmt* row)
 {
 	int         row_offset = 0;
-	const char* draft_text = NULL;
 
 	if (chat==NULL || chat->magic!=DC_CHAT_MAGIC || row==NULL) {
 		return 0;
@@ -376,25 +370,14 @@ static int set_from_stmt(dc_chat_t* chat, sqlite3_stmt* row)
 
 	dc_chat_empty(chat);
 
-	#define CHAT_FIELDS " c.id,c.type,c.name, c.draft_timestamp,c.draft_txt,c.grpid,c.param,c.archived, c.blocked "
+	#define CHAT_FIELDS " c.id,c.type,c.name, c.grpid,c.param,c.archived, c.blocked "
 	chat->id              =                    sqlite3_column_int  (row, row_offset++); /* the columns are defined in CHAT_FIELDS */
 	chat->type            =                    sqlite3_column_int  (row, row_offset++);
 	chat->name            =   dc_strdup((char*)sqlite3_column_text (row, row_offset++));
-	chat->draft_timestamp =                    sqlite3_column_int64(row, row_offset++);
-	draft_text            =       (const char*)sqlite3_column_text (row, row_offset++);
 	chat->grpid           =   dc_strdup((char*)sqlite3_column_text (row, row_offset++));
 	dc_param_set_packed(chat->param,    (char*)sqlite3_column_text (row, row_offset++));
 	chat->archived        =                    sqlite3_column_int  (row, row_offset++);
 	chat->blocked         =                    sqlite3_column_int  (row, row_offset++);
-
-	/* We leave a NULL-pointer for the very usual situation of "no draft".
-	Also make sure, draft_text and draft_timestamp are set together */
-	if (chat->draft_timestamp && draft_text && draft_text[0]) {
-		chat->draft_text = dc_strdup(draft_text);
-	}
-	else {
-		chat->draft_timestamp = 0;
-	}
 
 	/* correct the title of some special groups */
 	if (chat->id==DC_CHAT_ID_DEADDROP) {
@@ -1057,6 +1040,96 @@ cleanup:
 }
 
 
+static uint32_t get_draft_msg_id(dc_context_t* context, uint32_t chat_id)
+{
+	uint32_t draft_msg_id = 0;
+
+	sqlite3_stmt* stmt = dc_sqlite3_prepare(context->sql,
+		"SELECT id FROM msgs WHERE chat_id=? AND state=?;");
+	sqlite3_bind_int(stmt, 1, chat_id);
+	sqlite3_bind_int(stmt, 2, DC_STATE_OUT_DRAFT);
+	if (sqlite3_step(stmt)==SQLITE_ROW) {
+		draft_msg_id = sqlite3_column_int(stmt, 0);
+	}
+	sqlite3_finalize(stmt);
+
+	return draft_msg_id;
+}
+
+
+static int set_draft_raw(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
+{
+	// similar to as dc_set_draft() but does not send a message
+	sqlite3_stmt* stmt = NULL;
+	char*         pathNfilename = NULL;
+	uint32_t      prev_draft_msg_id = 0;
+	int           sth_changed = 0;
+
+	// delete old draft
+	prev_draft_msg_id = get_draft_msg_id(context, chat_id);
+	if (prev_draft_msg_id) {
+		dc_delete_msg_from_db(context, prev_draft_msg_id);
+		sth_changed = 1;
+	}
+
+	// save new draft
+	if (msg==NULL)
+	{
+		goto cleanup;
+	}
+	else if (msg->type==DC_MSG_TEXT)
+	{
+		if (msg->text==NULL || msg->text[0]==0) {
+			goto cleanup;
+		}
+	}
+	else if (DC_MSG_NEEDS_ATTACHMENT(msg->type))
+	{
+		pathNfilename = dc_param_get(msg->param, DC_PARAM_FILE, NULL);
+		if (pathNfilename==NULL) {
+			goto cleanup;
+		}
+
+		if (dc_msg_is_increation(msg) && !dc_is_blobdir_path(context, pathNfilename)) {
+			goto cleanup;
+		}
+
+		if (!dc_make_rel_and_copy(context, &pathNfilename)) {
+			goto cleanup;
+		}
+		dc_param_set(msg->param, DC_PARAM_FILE, pathNfilename);
+	}
+	else
+	{
+		goto cleanup;
+	}
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"INSERT INTO msgs (chat_id, from_id, timestamp,"
+		" type, state, txt, param, hidden)"
+		" VALUES (?,?,?, ?,?,?,?,?);");
+	sqlite3_bind_int  (stmt,  1, chat_id);
+	sqlite3_bind_int  (stmt,  2, DC_CONTACT_ID_SELF);
+	sqlite3_bind_int64(stmt,  3, time(NULL));
+	sqlite3_bind_int  (stmt,  4, msg->type);
+	sqlite3_bind_int  (stmt,  5, DC_STATE_OUT_DRAFT);
+	sqlite3_bind_text (stmt,  6, msg->text? msg->text : "",  -1, SQLITE_STATIC);
+	sqlite3_bind_text (stmt,  7, msg->param->packed, -1, SQLITE_STATIC);
+	sqlite3_bind_int  (stmt,  8, 1);
+	if (sqlite3_step(stmt)!=SQLITE_DONE) {
+		goto cleanup;
+	}
+
+	sth_changed = 1;
+
+
+cleanup:
+	sqlite3_finalize(stmt);
+	free(pathNfilename);
+	return sth_changed;
+}
+
+
 /**
  * Save a draft for a chat in the database.
  *
@@ -1085,49 +1158,13 @@ cleanup:
  */
 void dc_set_draft(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 {
-	sqlite3_stmt* stmt = NULL;
-	dc_chat_t*    chat = NULL;
-	const char*   text = NULL;
-
-	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC) {
-		goto cleanup;
+	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
+		return;
 	}
 
-	if ((chat=dc_get_chat(context, chat_id))==NULL) {
-		goto cleanup;
+	if (set_draft_raw(context, chat_id, msg)) {
+		context->cb(context, DC_EVENT_MSGS_CHANGED, chat_id, 0);
 	}
-
-	if (msg && msg->type==DC_MSG_TEXT && msg->text && msg->text[0]) {
-		text = msg->text;
-	}
-
-	if (chat->draft_text==NULL && text==NULL
-	 && chat->draft_timestamp==0) {
-		goto cleanup; // nothing to do - there is no old and no new draft
-	}
-
-	if (chat->draft_timestamp && chat->draft_text && text && strcmp(chat->draft_text, text)==0) {
-		goto cleanup; // for equal texts, we do not update the timestamp
-	}
-
-	// save draft in object - NULL or empty: clear draft
-	free(chat->draft_text);
-	chat->draft_text      = text? dc_strdup(text) : NULL;
-	chat->draft_timestamp = text? time(NULL) : 0;
-
-	// save draft in database
-	stmt = dc_sqlite3_prepare(context->sql,
-		"UPDATE chats SET draft_timestamp=?, draft_txt=? WHERE id=?;");
-	sqlite3_bind_int64(stmt, 1, chat->draft_timestamp);
-	sqlite3_bind_text (stmt, 2, chat->draft_text? chat->draft_text : "", -1, SQLITE_STATIC);
-	sqlite3_bind_int  (stmt, 3, chat->id);
-	sqlite3_step(stmt);
-
-	context->cb(context, DC_EVENT_MSGS_CHANGED, chat_id, 0);
-
-cleanup:
-	sqlite3_finalize(stmt);
-	dc_chat_unref(chat);
 }
 
 
@@ -1145,26 +1182,26 @@ cleanup:
  */
 dc_msg_t* dc_get_draft(dc_context_t* context, uint32_t chat_id)
 {
-	dc_chat_t* chat = NULL;
-	dc_msg_t*  msg = NULL;
+	uint32_t  draft_msg_id = 0;
+	dc_msg_t* draft_msg = NULL;
 
-	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC) {
-		goto cleanup;
+	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC
+	 || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
+		return NULL;
 	}
 
-	if ((chat=dc_get_chat(context, chat_id))==NULL) {
-		goto cleanup;
+	draft_msg_id = get_draft_msg_id(context, chat_id);
+	if (draft_msg_id==0) {
+		return NULL;
 	}
 
-	if (chat->draft_text && chat->draft_text[0]) {
-		msg = dc_msg_new(context, DC_MSG_TEXT);
-		msg->text = dc_strdup(chat->draft_text);
-		msg->timestamp = chat->draft_timestamp;
+	draft_msg = dc_msg_new_untyped(context);
+	if (!dc_msg_load_from_db(draft_msg, context, draft_msg_id)) {
+		dc_msg_unref(draft_msg);
+		return NULL;
 	}
 
-cleanup:
-	dc_chat_unref(chat);
-	return msg;
+	return draft_msg;
 }
 
 
@@ -1591,6 +1628,7 @@ uint32_t dc_create_group_chat(dc_context_t* context, int verified, const char* c
 {
 	uint32_t      chat_id = 0;
 	char*         draft_txt = NULL;
+	dc_msg_t*     draft_msg = NULL;
 	char*         grpid = NULL;
 	sqlite3_stmt* stmt = NULL;
 
@@ -1602,12 +1640,10 @@ uint32_t dc_create_group_chat(dc_context_t* context, int verified, const char* c
 	grpid = dc_create_id();
 
 	stmt = dc_sqlite3_prepare(context->sql,
-		"INSERT INTO chats (type, name, draft_timestamp, draft_txt, grpid, param) VALUES(?, ?, ?, ?, ?, 'U=1');" /*U=DC_PARAM_UNPROMOTED*/);
+		"INSERT INTO chats (type, name, grpid, param) VALUES(?, ?, ?, 'U=1');" /*U=DC_PARAM_UNPROMOTED*/);
 	sqlite3_bind_int  (stmt, 1, verified? DC_CHAT_TYPE_VERIFIED_GROUP : DC_CHAT_TYPE_GROUP);
 	sqlite3_bind_text (stmt, 2, chat_name, -1, SQLITE_STATIC);
-	sqlite3_bind_int64(stmt, 3, time(NULL));
-	sqlite3_bind_text (stmt, 4, draft_txt, -1, SQLITE_STATIC);
-	sqlite3_bind_text (stmt, 5, grpid, -1, SQLITE_STATIC);
+	sqlite3_bind_text (stmt, 3, grpid, -1, SQLITE_STATIC);
 	if ( sqlite3_step(stmt)!=SQLITE_DONE) {
 		goto cleanup;
 	}
@@ -1620,9 +1656,14 @@ uint32_t dc_create_group_chat(dc_context_t* context, int verified, const char* c
 		goto cleanup;
 	}
 
+	draft_msg = dc_msg_new(context, DC_MSG_TEXT);
+	dc_msg_set_text(draft_msg, draft_txt);
+	set_draft_raw(context, chat_id, draft_msg);
+
 cleanup:
 	sqlite3_finalize(stmt);
 	free(draft_txt);
+	dc_msg_unref(draft_msg);
 	free(grpid);
 
 	if (chat_id) {

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -1059,7 +1059,7 @@ static uint32_t get_draft_msg_id(dc_context_t* context, uint32_t chat_id)
 
 static int set_draft_raw(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 {
-	// similar to as dc_set_draft() but does not send a message
+	// similar to as dc_set_draft() but does not emit an event
 	sqlite3_stmt* stmt = NULL;
 	char*         pathNfilename = NULL;
 	uint32_t      prev_draft_msg_id = 0;

--- a/src/dc_chat.h
+++ b/src/dc_chat.h
@@ -19,8 +19,6 @@ struct _dc_chat
 	uint32_t        id;
 	int             type;             /**< Chat type. Use dc_chat_get_type() to access this field. */
 	char*           name;             /**< Name of the chat. Use dc_chat_get_name() to access this field. NULL if unset. */
-	char*           draft_text;	    /**< Draft text. NULL if there is no draft. */
-	time_t          draft_timestamp;  /**< Timestamp of the draft. 0 if there is no draft. */
 	int             archived;         /**< Archived state. Better use dc_chat_get_archived() to access this object. */
 	dc_context_t*   context;          /**< The context object the chat belongs to. */
 	char*           grpid;            /**< Group ID that is used by all clients. Only used if the chat is a group. NULL if unset */

--- a/src/dc_chatlist.c
+++ b/src/dc_chatlist.c
@@ -281,12 +281,23 @@ static int dc_chatlist_load_from_db(dc_chatlist_t* chatlist, int listflags, cons
 
 	dc_chatlist_empty(chatlist);
 
-	/* select example with left join and minimum: http://stackoverflow.com/questions/7588142/mysql-left-join-min */
+	// select with left join and minimum:
+	// - the inner select must use `hidden` and _not_ `m.hidden`
+	//   which would refer the outer select and take a lot of time
+	// - `GROUP BY` is needed several messages may have the same timestamp
+	// - the list starts with the newest chats
 	#define QUR1 "SELECT c.id, m.id FROM chats c " \
-	                " LEFT JOIN msgs m ON (c.id=m.chat_id AND m.hidden=0 AND m.timestamp=(SELECT MAX(timestamp) FROM msgs WHERE chat_id=c.id AND hidden=0)) " /* not: `m.hidden` which would refer the outer select and takes lot of time*/ \
-	                " WHERE c.id>" DC_STRINGIFY(DC_CHAT_ID_LAST_SPECIAL) " AND c.blocked=0"
-	#define QUR2    " GROUP BY c.id " /* GROUP BY is needed as there may be several messages with the same timestamp */ \
-	                " ORDER BY IFNULL(m.timestamp,0) DESC,m.id DESC;" /* the list starts with the newest chats */
+	             " LEFT JOIN msgs m " \
+	             "        ON c.id=m.chat_id " \
+	             "       AND m.timestamp=( " \
+	                         "SELECT MAX(timestamp) " \
+	                         "  FROM msgs " \
+	                         " WHERE chat_id=c.id " \
+	                         "   AND (hidden=0 OR (hidden=1 AND state=" DC_STRINGIFY(DC_STATE_OUT_DRAFT) ")))" \
+	             " WHERE c.id>" DC_STRINGIFY(DC_CHAT_ID_LAST_SPECIAL) \
+	             "   AND c.blocked=0"
+	#define QUR2 " GROUP BY c.id " \
+	             " ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;"
 
 	// nb: the query currently shows messages from blocked contacts in groups.
 	// however, for normal-groups, this is okay as the message is also returned by dc_get_chat_msgs()

--- a/src/dc_chatlist.c
+++ b/src/dc_chatlist.c
@@ -199,19 +199,6 @@ dc_lot_t* dc_chatlist_get_summary(const dc_chatlist_t* chatlist, size_t index, d
 	{
 		ret->text2 = dc_strdup(NULL);
 	}
-	else if (chat->draft_timestamp
-	      && chat->draft_text
-	      && (lastmsg==NULL || chat->draft_timestamp>lastmsg->timestamp))
-	{
-		/* show the draft as the last message */
-		ret->text1 = dc_stock_str(chatlist->context, DC_STR_DRAFT);
-		ret->text1_meaning = DC_TEXT1_DRAFT;
-
-		ret->text2 = dc_strdup(chat->draft_text);
-		dc_truncate_n_unwrap_str(ret->text2, DC_SUMMARY_CHARACTERS, 1/*unwrap*/);
-
-		ret->timestamp = chat->draft_timestamp;
-	}
 	else if (lastmsg==NULL || lastmsg->from_id==0)
 	{
 		/* no messages */
@@ -299,7 +286,7 @@ static int dc_chatlist_load_from_db(dc_chatlist_t* chatlist, int listflags, cons
 	                " LEFT JOIN msgs m ON (c.id=m.chat_id AND m.hidden=0 AND m.timestamp=(SELECT MAX(timestamp) FROM msgs WHERE chat_id=c.id AND hidden=0)) " /* not: `m.hidden` which would refer the outer select and takes lot of time*/ \
 	                " WHERE c.id>" DC_STRINGIFY(DC_CHAT_ID_LAST_SPECIAL) " AND c.blocked=0"
 	#define QUR2    " GROUP BY c.id " /* GROUP BY is needed as there may be several messages with the same timestamp */ \
-	                " ORDER BY MAX(c.draft_timestamp, IFNULL(m.timestamp,0)) DESC,m.id DESC;" /* the list starts with the newest chats */
+	                " ORDER BY IFNULL(m.timestamp,0) DESC,m.id DESC;" /* the list starts with the newest chats */
 
 	// nb: the query currently shows messages from blocked contacts in groups.
 	// however, for normal-groups, this is okay as the message is also returned by dc_get_chat_msgs()

--- a/src/dc_lot.c
+++ b/src/dc_lot.c
@@ -181,7 +181,12 @@ void dc_lot_fill(dc_lot_t* lot, const dc_msg_t* msg, const dc_chat_t* chat, cons
 		return;
 	}
 
-	if (msg->from_id==DC_CONTACT_ID_SELF)
+	if (msg->state==DC_STATE_OUT_DRAFT)
+	{
+		lot->text1 = dc_stock_str(context, DC_STR_DRAFT);
+		lot->text1_meaning = DC_TEXT1_DRAFT;
+	}
+	else if (msg->from_id==DC_CONTACT_ID_SELF)
 	{
 		if (dc_msg_is_info(msg)) {
 			lot->text1 = NULL;

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1594,6 +1594,80 @@ void dc_star_msgs(dc_context_t* context, const uint32_t* msg_ids, int msg_cnt, i
  ******************************************************************************/
 
 
+ /**
+  * Low-level function to delete a message from the database.
+  * This does not delete the messages from the server.
+  *
+  * @private @memberof dc_context_t
+  */
+void dc_delete_msg_from_db(dc_context_t* context, uint32_t msg_id)
+{
+	dc_msg_t*     msg = dc_msg_new_untyped(context);
+	sqlite3_stmt* stmt = NULL;
+
+	if (!dc_msg_load_from_db(msg, context, msg_id)) {
+		goto cleanup;
+	}
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"DELETE FROM msgs WHERE id=?;");
+	sqlite3_bind_int(stmt, 1, msg->id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	stmt = NULL;
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"DELETE FROM msgs_mdns WHERE msg_id=?;");
+	sqlite3_bind_int(stmt, 1, msg->id);
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+	stmt = NULL;
+
+	char* pathNfilename = dc_param_get(msg->param, DC_PARAM_FILE, NULL);
+	if (pathNfilename) {
+		if (strncmp("$BLOBDIR", pathNfilename, 8)==0)
+		{
+			char* strLikeFilename = dc_mprintf("%%f=%s%%", pathNfilename);
+			stmt = dc_sqlite3_prepare(context->sql,
+				"SELECT id FROM msgs WHERE type!=? AND param LIKE ?;"); /* if this gets too slow, an index over "type" should help. */
+			sqlite3_bind_int (stmt, 1, DC_MSG_TEXT);
+			sqlite3_bind_text(stmt, 2, strLikeFilename, -1, SQLITE_STATIC);
+			int file_used_by_other_msgs = (sqlite3_step(stmt)==SQLITE_ROW)? 1 : 0;
+			free(strLikeFilename);
+			sqlite3_finalize(stmt);
+			stmt = NULL;
+
+			if (!file_used_by_other_msgs)
+			{
+				dc_delete_file(context, pathNfilename);
+
+				char* increation_file = dc_mprintf("%s.increation", pathNfilename);
+				dc_delete_file(context, increation_file);
+				free(increation_file);
+
+				char* filenameOnly = dc_get_filename(pathNfilename);
+				if (msg->type==DC_MSG_VOICE) {
+					char* waveform_file = dc_mprintf("%s/%s.waveform", context->blobdir, filenameOnly);
+					dc_delete_file(context, waveform_file);
+					free(waveform_file);
+				}
+				else if (msg->type==DC_MSG_VIDEO) {
+					char* preview_file = dc_mprintf("%s/%s-preview.jpg", context->blobdir, filenameOnly);
+					dc_delete_file(context, preview_file);
+					free(preview_file);
+				}
+				free(filenameOnly);
+			}
+		}
+		free(pathNfilename);
+	}
+
+cleanup:
+	sqlite3_finalize(stmt);
+	dc_msg_unref(msg);
+}
+
+
 /**
  * Delete messages. The messages are deleted on the current device and
  * on the IMAP server.

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -73,6 +73,8 @@ char*           dc_msg_get_summarytext_by_raw         (int type, const char* tex
 void            dc_msg_save_param_to_disk             (dc_msg_t*);
 void            dc_msg_guess_msgtype_from_suffix      (const char* pathNfilename, int* ret_msgtype, char** ret_mime);
 
+void            dc_delete_msg_from_db                 (dc_context_t*, uint32_t);
+
 #define DC_MSG_NEEDS_ATTACHMENT(a)         ((a)==DC_MSG_IMAGE || (a)==DC_MSG_GIF || (a)==DC_MSG_AUDIO || (a)==DC_MSG_VOICE || (a)==DC_MSG_VIDEO || (a)==DC_MSG_FILE)
 
 

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -489,6 +489,7 @@ typedef struct _dc_msg dc_msg_t;
 #define         DC_STATE_IN_FRESH            10
 #define         DC_STATE_IN_NOTICED          13
 #define         DC_STATE_IN_SEEN             16
+#define         DC_STATE_OUT_DRAFT           19
 #define         DC_STATE_OUT_PENDING         20
 #define         DC_STATE_OUT_FAILED          24
 #define         DC_STATE_OUT_DELIVERED       26 // to check if a mail was sent, use dc_msg_is_sent()


### PR DESCRIPTION
in #457 we've changed the draft api so that it can set/get any `dc_msg_t` object as a draft - however, internally, still only text drafts were stored.

this pr changes the internal behavior so that the given `dc_msg_t` objects are really stored as drafts and can be restored later.

internal changes:
- draft are saved as messages in the normal `msgs` database
- the draft records are stored with the states `hidden=1` and `state=DC_STATE_OUT_DRAFT`
- each chat can have one draft (more are possible theoretically, however, currently a `dc_set_draft()` just overwrites the existing one for the given chat_id)
- loading the old draft texts/timestamps from the chats table removed
- reworking the sql commands

closes #214