### PR TITLE
ignore case when calculating colors

### DIFF
--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -606,6 +606,8 @@ clist* dc_str_to_clist(const char* str, const char* delimiter)
 
 int dc_str_to_color(const char* str)
 {
+	char* str_lower = dc_strlower(str);
+
 	static uint32_t colors[] = {
 		0xe56555,
 		0xf28c48,
@@ -618,14 +620,15 @@ int dc_str_to_color(const char* str)
 	};
 
 	int checksum = 0;
-	int str_len = strlen(str);
+	int str_len = strlen(str_lower);
 	for (int i = 0; i < str_len; i++) {
-		checksum += (i+1)*str[i];
+		checksum += (i+1)*str_lower[i];
 		checksum %= 0x00FFFFFF;
 	}
 
 	int color_index = checksum % (sizeof(colors)/sizeof(uint32_t));
 
+	free(str_lower);
 	return colors[color_index];
 }
 


### PR DESCRIPTION
before going to the harder parts ;)

this pr changes the calculation contact/chat colors so that it becomes case-insensitive.

- on a multi-device-setup, this ensures, the fallback colors are the same for User@example.org and user@example.org
- as a side-effect, for chats, the color is not changed when just the case of the group name changes, which is also nice to have :)