### PR TITLE
[wip] move chat messages away

### DIFF
--- a/src/dc_chat.h
+++ b/src/dc_chat.h
@@ -33,7 +33,6 @@ int             dc_chat_update_param               (dc_chat_t*);
 #define         DC_CHAT_TYPE_CAN_SEND(a)   ((a)==DC_CHAT_TYPE_SINGLE || (a)==DC_CHAT_TYPE_GROUP || (a)==DC_CHAT_TYPE_VERIFIED_GROUP)
 
 #define         DC_CHAT_PREFIX              "Chat:"      /* you MUST NOT modify this or the following strings */
-#define         DC_CHATS_FOLDER             "DeltaChat"  // make sure not to use reserved words here, eg. "Chats" or "Chat" are reserved in gmail
 
 
 // Context functions to work with chats

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -381,6 +381,166 @@ cleanup:
 
 
 /*******************************************************************************
+ * Check IMAP-folders
+ ******************************************************************************/
+
+
+typedef struct dc_imapfolder_t
+{
+	char* name_to_select;
+	char* name_utf8;
+} dc_imapfolder_t;
+
+
+static clist* list_folders(dc_imap_t* imap)
+{
+	clist*     imap_list = NULL;
+	clistiter* iter1 = NULL;
+	clist *    ret_list = clist_new();
+	int        r = 0;
+
+	if (imap==NULL || imap->etpan==NULL) {
+		goto cleanup;
+	}
+
+	// the "*" also returns all subdirectories;
+	// so the resulting foldernames may contain
+	// foldernames with delimiters as "folder/subdir/subsubdir"
+	//
+	// when switching to XLIST: at least my server claims
+	// that it support XLIST but does not return folder flags.
+	// so, if we did not get a _single_ flag, sth. seems not to work.
+	r = mailimap_list(imap->etpan, "", "*", &imap_list);
+
+	if (dc_imap_is_error(imap, r) || imap_list==NULL) {
+		imap_list = NULL;
+		dc_log_warning(imap->context, 0, "Cannot get folder list.");
+		goto cleanup;
+	}
+
+	if (clist_count(imap_list)<=0) {
+		dc_log_warning(imap->context, 0, "Folder list is empty.");
+		goto cleanup;
+	}
+
+	// default IMAP delimiter if none is returned by the list command
+	imap->imap_delimiter = '.';
+	for (iter1 = clist_begin(imap_list); iter1!=NULL ; iter1 = clist_next(iter1))
+	{
+		struct mailimap_mailbox_list* imap_folder =
+			(struct mailimap_mailbox_list*)clist_content(iter1);
+
+		if (imap_folder->mb_delimiter) {
+			imap->imap_delimiter = imap_folder->mb_delimiter;
+		}
+
+		dc_imapfolder_t* ret_folder = calloc(1, sizeof(dc_imapfolder_t));
+
+		if (strcasecmp(imap_folder->mb_name, "INBOX")==0) {
+			// Force upper case INBOX. Servers may return any case, however,
+			// all variants MUST lead to the same INBOX, see RFC 3501 5.1
+			ret_folder->name_to_select = dc_strdup("INBOX");
+		}
+		else {
+			ret_folder->name_to_select = dc_strdup(imap_folder->mb_name);
+		}
+
+		ret_folder->name_utf8 = dc_decode_modified_utf7(imap_folder->mb_name, 0);
+
+		clist_append(ret_list, (void*)ret_folder);
+	}
+
+cleanup:
+	if (imap_list) {
+		mailimap_list_result_free(imap_list);
+	}
+	return ret_list;
+}
+
+
+static void free_folders(clist* folders)
+{
+	if (folders) {
+		clistiter* iter1;
+		for (iter1 = clist_begin(folders); iter1!=NULL ; iter1 = clist_next(iter1)) {
+			dc_imapfolder_t* ret_folder = (struct dc_imapfolder_t*)clist_content(iter1);
+			free(ret_folder->name_to_select);
+			free(ret_folder->name_utf8);
+			free(ret_folder);
+		}
+		clist_free(folders);
+	}
+}
+
+
+void dc_imap_configure_folders(dc_imap_t* imap)
+{
+	#define DC_DEF_MVBOX "DeltaChat"
+
+	clist*     folder_list = NULL;
+	clistiter* iter;
+	char*      mvbox_folder = NULL;
+	char*      fallback_folder = NULL;
+
+	if (imap==NULL || imap->etpan==NULL) {
+		goto cleanup;
+	}
+
+	// this sets imap->imap_delimiter as side-effect
+	folder_list = list_folders(imap);
+
+	// as a fallback, the mvbox_folder is created under INBOX
+	// as required e.g. for DomainFactory
+	fallback_folder = dc_mprintf("INBOX%c%s", imap->imap_delimiter, DC_DEF_MVBOX);
+	for (iter=clist_begin(folder_list); iter!=NULL; iter=clist_next(iter))
+	{
+		dc_imapfolder_t* folder = (struct dc_imapfolder_t*)clist_content(iter);
+		if (strcmp(folder->name_utf8, DC_DEF_MVBOX)==0
+		 || strcmp(folder->name_utf8, fallback_folder)==0) {
+			mvbox_folder = dc_strdup(folder->name_to_select);
+			break;
+		}
+	}
+
+	if (mvbox_folder==NULL)
+	{
+		dc_log_info(imap->context, 0, "Creating MVBOX-folder \"%s\"...", DC_DEF_MVBOX);
+		int r = mailimap_create(imap->etpan, DC_DEF_MVBOX);
+		if (dc_imap_is_error(imap, r)) {
+			dc_log_warning(imap->context, 0, "Cannot create MVBOX-folder, using trying INBOX subfolder.");
+			r = mailimap_create(imap->etpan, fallback_folder);
+			if (dc_imap_is_error(imap, r)) {
+				/* continue on errors, we'll just use a different folder then */
+				dc_log_warning(imap->context, 0, "Cannot create MVBOX-folder.");
+			}
+			else {
+				mvbox_folder = dc_strdup(fallback_folder);
+				dc_log_info(imap->context, 0, "MVBOX-folder created as INBOX subfolder.");
+			}
+		}
+		else {
+			mvbox_folder = dc_strdup(DC_DEF_MVBOX);
+			dc_log_info(imap->context, 0, "MVBOX-folder created.");
+		}
+
+		// SUBSCRIBE is needed to make the folder visible to the LSUB command
+		// that may be used by other MUAs to list folders.
+		// for the LIST command, the folder is always visible.
+		mailimap_subscribe(imap->etpan, mvbox_folder);
+	}
+
+	// remember the configuration, mvbox_folder may be NULL
+	dc_sqlite3_set_config_int(imap->context->sql, "configured_mvbox", 1);
+	dc_sqlite3_set_config(imap->context->sql, "configured_mvbox_folder", mvbox_folder);
+
+cleanup:
+	free_folders(folder_list);
+	free(mvbox_folder);
+	free(fallback_folder);
+}
+
+
+/*******************************************************************************
  * Main interface
  ******************************************************************************/
 
@@ -391,6 +551,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	int              imap_connected_here = 0;
 	int              smtp_connected_here = 0;
 	int              ongoing_allocated_here = 0;
+	char*            mvbox_folder = NULL;
 
 	dc_loginparam_t* param = NULL;
 	char*            param_domain = NULL; /* just a pointer inside param, must not be freed! */
@@ -689,10 +850,9 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	/* find out wheter `DeltaChat`, `INBOX/DeltaChat` or whatever
 	should be used as the MVBOX */
 
-	// TODO
+	dc_imap_configure_folders(context->inbox);
 
-	PROGRESS(910)
-
+	PROGRESS(910);
 
 	/* configuration success - write back the configured parameters with the "configured_" prefix; also write the "configured"-flag */
 
@@ -726,6 +886,7 @@ cleanup:
 	if (ongoing_allocated_here) {
 		dc_free_ongoing(context);
 	}
+	free(mvbox_folder);
 
 	context->cb(context, DC_EVENT_CONFIGURE_PROGRESS, success? 1000 : 0, 0);
 }

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -636,7 +636,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	(the part before the '@') */
 	{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
-	if (!dc_imap_connect(context->inbox, param)) {
+	if (!dc_imap_connect(context->inbox, param, "INBOX")) {
 		if (param_autoconfig) {
 			goto cleanup;
 		}
@@ -655,7 +655,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 
 		{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
-		if (!dc_imap_connect(context->inbox, param)) {
+		if (!dc_imap_connect(context->inbox, param, "INBOX")) {
 			goto cleanup;
 		}
 	}
@@ -685,6 +685,14 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	smtp_connected_here = 1;
 
 	PROGRESS(900)
+
+	/* find out wheter `DeltaChat`, `INBOX/DeltaChat` or whatever
+	should be used as the MVBOX */
+
+	// TODO
+
+	PROGRESS(910)
+
 
 	/* configuration success - write back the configured parameters with the "configured_" prefix; also write the "configured"-flag */
 

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -489,7 +489,8 @@ void dc_imap_configure_folders(dc_imap_t* imap)
 
 	dc_log_info(imap->context, 0, "Configuring IMAP-folders.");
 
-	mvbox_enabled = dc_sqlite3_get_config_int(imap->context->sql, "mvbox_enabled", 0);
+	mvbox_enabled = dc_sqlite3_get_config_int(imap->context->sql,
+		"mvbox_enabled", DC_MVBOX_DEFAULT_ENABLED);
 
 	// this sets imap->imap_delimiter as side-effect
 	folder_list = list_folders(imap);

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -486,6 +486,8 @@ void dc_imap_configure_folders(dc_imap_t* imap)
 		goto cleanup;
 	}
 
+	dc_log_info(imap->context, 0, "Configuring IMAP-folders.");
+
 	// this sets imap->imap_delimiter as side-effect
 	folder_list = list_folders(imap);
 
@@ -797,7 +799,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	(the part before the '@') */
 	{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
-	if (!dc_imap_connect(context->inbox, param, "INBOX")) {
+	if (!dc_imap_connect(context->inbox, param)) {
 		if (param_autoconfig) {
 			goto cleanup;
 		}
@@ -816,7 +818,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 
 		{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
-		if (!dc_imap_connect(context->inbox, param, "INBOX")) {
+		if (!dc_imap_connect(context->inbox, param)) {
 			goto cleanup;
 		}
 	}

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -415,12 +415,14 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 		goto cleanup;
 	}
 
-	dc_imap_disconnect(context->imap);
+	dc_imap_disconnect(context->inbox);
+	dc_imap_disconnect(context->mvbox);
 	dc_smtp_disconnect(context->smtp);
 
 	//dc_sqlite3_set_config_int(context->sql, "configured", 0); -- NO: we do _not_ reset this flag if it was set once; otherwise the user won't get back to his chats (as an alternative, we could change the UI).  Moreover, and not changeable in the UI, we use this flag to check if we shall search for backups.
 	context->smtp->log_connect_errors = 1;
-	context->imap->log_connect_errors = 1;
+	context->inbox->log_connect_errors = 1;
+	context->mvbox->log_connect_errors = 1;
 
 	dc_log_info(context, 0, "Configure ...");
 
@@ -634,7 +636,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 	(the part before the '@') */
 	{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
-	if (!dc_imap_connect(context->imap, param)) {
+	if (!dc_imap_connect(context->inbox, param)) {
 		if (param_autoconfig) {
 			goto cleanup;
 		}
@@ -653,7 +655,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 
 		{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
-		if (!dc_imap_connect(context->imap, param)) {
+		if (!dc_imap_connect(context->inbox, param)) {
 			goto cleanup;
 		}
 	}
@@ -703,7 +705,7 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 
 cleanup:
 	if (imap_connected_here) {
-		dc_imap_disconnect(context->imap);
+		dc_imap_disconnect(context->inbox);
 	}
 
 	if (smtp_connected_here) {

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -130,7 +130,8 @@ dc_context_t* dc_context_new(dc_callback_t cb, void* userdata, const char* os_na
 
 	pthread_mutex_init(&context->smear_critical, NULL);
 	pthread_mutex_init(&context->bobs_qr_critical, NULL);
-	pthread_mutex_init(&context->imapidle_condmutex, NULL);
+	pthread_mutex_init(&context->inboxidle_condmutex, NULL);
+	pthread_mutex_init(&context->mvboxidle_condmutex, NULL);
 	pthread_mutex_init(&context->smtpidle_condmutex, NULL);
 	pthread_cond_init(&context->smtpidle_cond, NULL);
 
@@ -144,7 +145,8 @@ dc_context_t* dc_context_new(dc_callback_t cb, void* userdata, const char* os_na
 
 	dc_pgp_init();
 	context->sql      = dc_sqlite3_new(context);
-	context->imap     = dc_imap_new(cb_get_config, cb_set_config, cb_receive_imf, (void*)context, context);
+	context->inbox    = dc_imap_new(cb_get_config, cb_set_config, cb_receive_imf, (void*)context, context);
+	context->mvbox    = dc_imap_new(cb_get_config, cb_set_config, cb_receive_imf, (void*)context, context);
 	context->smtp     = dc_smtp_new(context);
 
 	/* Random-seed.  An additional seed with more random data is done just before key generation
@@ -187,7 +189,8 @@ void dc_context_unref(dc_context_t* context)
 		dc_close(context);
 	}
 
-	dc_imap_unref(context->imap);
+	dc_imap_unref(context->inbox);
+	dc_imap_unref(context->mvbox);
 	dc_smtp_unref(context->smtp);
 	dc_sqlite3_unref(context->sql);
 
@@ -195,7 +198,8 @@ void dc_context_unref(dc_context_t* context)
 
 	pthread_mutex_destroy(&context->smear_critical);
 	pthread_mutex_destroy(&context->bobs_qr_critical);
-	pthread_mutex_destroy(&context->imapidle_condmutex);
+	pthread_mutex_destroy(&context->inboxidle_condmutex);
+	pthread_mutex_destroy(&context->mvboxidle_condmutex);
 	pthread_cond_destroy(&context->smtpidle_cond);
 	pthread_mutex_destroy(&context->smtpidle_condmutex);
 
@@ -295,7 +299,8 @@ void dc_close(dc_context_t* context)
 		return;
 	}
 
-	dc_imap_disconnect(context->imap);
+	dc_imap_disconnect(context->inbox);
+	dc_imap_disconnect(context->mvbox);
 	dc_smtp_disconnect(context->smtp);
 
 	if (dc_sqlite3_is_open(context->sql)) {

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -133,6 +133,7 @@ dc_context_t* dc_context_new(dc_callback_t cb, void* userdata, const char* os_na
 	pthread_mutex_init(&context->bobs_qr_critical, NULL);
 	pthread_mutex_init(&context->inboxidle_condmutex, NULL);
 	pthread_mutex_init(&context->mvboxidle_condmutex, NULL);
+	pthread_cond_init(&context->mvboxidle_cond, NULL);
 	pthread_mutex_init(&context->smtpidle_condmutex, NULL);
 	pthread_cond_init(&context->smtpidle_cond, NULL);
 
@@ -200,6 +201,7 @@ void dc_context_unref(dc_context_t* context)
 	pthread_mutex_destroy(&context->smear_critical);
 	pthread_mutex_destroy(&context->bobs_qr_critical);
 	pthread_mutex_destroy(&context->inboxidle_condmutex);
+	pthread_cond_destroy(&context->mvboxidle_cond);
 	pthread_mutex_destroy(&context->mvboxidle_condmutex);
 	pthread_cond_destroy(&context->smtpidle_cond);
 	pthread_mutex_destroy(&context->smtpidle_condmutex);

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -646,7 +646,7 @@ char* dc_get_info(dc_context_t* context)
 	l_readable_str = dc_loginparam_get_readable(l);
 	l2_readable_str = dc_loginparam_get_readable(l2);
 
-	mvbox_enabled = dc_sqlite3_get_config_int(context->sql, "mvbox_enabled", 0);
+	mvbox_enabled = dc_sqlite3_get_config_int(context->sql, "mvbox_enabled", DC_MVBOX_DEFAULT_ENABLED);
 	configured_mvbox = dc_sqlite3_get_config_int(context->sql, "configured_mvbox", 0);
 	configured_mvbox_folder = dc_sqlite3_get_config(context->sql, "configured_mvbox_folder", "<unset>");
 

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -579,6 +579,8 @@ char* dc_get_info(dc_context_t* context)
 	char*            fingerprint_str = NULL;
 	dc_loginparam_t* l = NULL;
 	dc_loginparam_t* l2 = NULL;
+	int              configured_mvbox = 0;
+	char*            configured_mvbox_folder = NULL;
 	int              contacts = 0;
 	int              chats = 0;
 	int              real_msgs = 0;
@@ -637,6 +639,12 @@ char* dc_get_info(dc_context_t* context)
 	l_readable_str = dc_loginparam_get_readable(l);
 	l2_readable_str = dc_loginparam_get_readable(l2);
 
+	configured_mvbox = dc_sqlite3_get_config_int(context->sql,
+		"configured_mvbox", 0);
+
+	configured_mvbox_folder = dc_sqlite3_get_config(context->sql,
+		"configured_mvbox_folder", "<unset>");
+
 	temp = dc_mprintf(
 		"deltachat_core_version=v%s\n"
 		"sqlite_version=%s\n"
@@ -656,6 +664,8 @@ char* dc_get_info(dc_context_t* context)
 		"is_configured=%i\n"
 		"entered_account_settings=%s\n"
 		"used_account_settings=%s\n"
+		"configured_mvbox=%i\n"
+		"configured_mvbox_folder=%s\n"
 		"mdns_enabled=%i\n"
 		"e2ee_enabled=%i\n"
 		"e2ee_default_enabled=%i\n"
@@ -680,6 +690,8 @@ char* dc_get_info(dc_context_t* context)
 		, is_configured
 		, l_readable_str
 		, l2_readable_str
+		, configured_mvbox
+		, configured_mvbox_folder
 		, mdns_enabled
 		, e2ee_enabled
 		, DC_E2EE_DEFAULT_ENABLED
@@ -696,6 +708,7 @@ char* dc_get_info(dc_context_t* context)
 	free(displayname);
 	free(l_readable_str);
 	free(l2_readable_str);
+	free(configured_mvbox_folder);
 	free(fingerprint_str);
 	dc_key_unref(self_public);
 	return ret.buf; /* must be freed by the caller */

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -431,6 +431,9 @@ static char* get_sys_config_str(const char* key)
  * - `send_port`    = SMTP-port, guessed if left out
  * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
  * - `imap_folder`  = IMAP-folder to use, defaults to `INBOX`
+ * - `mvbox_folder` = IMAP-folder to use for moving messages
+ *                    out of the scope or normal MUAs,
+ *                    defaults to `DeltaChat` or `INBOX/DeltaChat`
  * - `displayname`  = Own name to use when sending messages.  MUAs are allowed to spread this way eg. using CC, defaults to empty
  * - `selfstatus`   = Own status to display eg. in email footers, defaults to a standard text
  * - `selfavatar`   = File containing avatar. Will be copied to blob directory.

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -53,7 +53,11 @@ struct _dc_context
 	int              probe_imap_network;    /**< if this flag is set, the imap-job timeouts are bypassed and messages are sent until they fail */
 
 	dc_imap_t*       mvbox;                 /**< secondary IMAP object watching the delta chat folder, never NULL */
+	pthread_cond_t   mvboxidle_cond;
 	pthread_mutex_t  mvboxidle_condmutex;
+	int              mvboxidle_condflag;
+	int              mvbox_suspended;
+	int              mvbox_using_handle;
 
 	dc_smtp_t*       smtp;                  /**< Internal SMTP object, never NULL */
 	pthread_cond_t   smtpidle_cond;

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -141,7 +141,6 @@ int             dc_has_ongoing       (dc_context_t*);
 int             dc_alloc_ongoing     (dc_context_t*);
 void            dc_free_ongoing      (dc_context_t*);
 
-
 /* library private: secure-join */
 #define         DC_HANDSHAKE_CONTINUE_NORMAL_PROCESSING 0x01
 #define         DC_HANDSHAKE_STOP_NORMAL_PROCESSING     0x02

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -111,10 +111,13 @@ void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_ter
 #define DC_MSGSIZE_UPPER_LIMIT      ((49*1024*1024)/4*3)
 
 
-/* library private: end-to-end-encryption */
-#define DC_E2EE_DEFAULT_ENABLED  1
-#define DC_MDNS_DEFAULT_ENABLED  1
+// some defaults
+#define DC_E2EE_DEFAULT_ENABLED   1
+#define DC_MDNS_DEFAULT_ENABLED   1
+#define DC_MVBOX_DEFAULT_ENABLED  1
 
+
+/* library private: end-to-end-encryption */
 typedef struct dc_e2ee_helper_t {
 	// encryption
 	int        encryption_successfull;

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -47,10 +47,13 @@ struct _dc_context
 
 	dc_sqlite3_t*    sql;                   /**< Internal SQL object, never NULL */
 
-	dc_imap_t*       imap;                  /**< Internal IMAP object, never NULL */
-	pthread_mutex_t  imapidle_condmutex;
-	int              perform_imap_jobs_needed;
+	dc_imap_t*       inbox;                 /**< primary IMAP object watching the inbox, never NULL */
+	pthread_mutex_t  inboxidle_condmutex;
+	int              perform_inbox_jobs_needed;
 	int              probe_imap_network;    /**< if this flag is set, the imap-job timeouts are bypassed and messages are sent until they fail */
+
+	dc_imap_t*       mvbox;                 /**< secondary IMAP object watching the delta chat folder, never NULL */
+	pthread_mutex_t  mvboxidle_condmutex;
 
 	dc_smtp_t*       smtp;                  /**< Internal SMTP object, never NULL */
 	pthread_cond_t   smtpidle_cond;

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -126,7 +126,7 @@ static int select_folder(dc_imap_t* imap, const char* folder /*may be NULL*/)
 
 	/* if there is a new folder and the new folder is equal to the selected one, there's nothing to do.
 	if there is _no_ new folder, we continue as we might want to expunge below.  */
-	if (folder && strcmp(imap->selected_folder, folder)==0) {
+	if (folder && folder[0] && strcmp(imap->selected_folder, folder)==0) {
 		return 1;
 	}
 

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -842,12 +842,11 @@ static void free_connect_param(dc_imap_t* imap)
 }
 
 
-int dc_imap_connect(dc_imap_t* imap, const dc_loginparam_t* lp,
-                    const char* watch_folder)
+int dc_imap_connect(dc_imap_t* imap, const dc_loginparam_t* lp)
 {
 	int success = 0;
 
-	if (imap==NULL || lp==NULL || watch_folder==NULL
+	if (imap==NULL || lp==NULL
 	 || lp->mail_server==NULL || lp->mail_user==NULL || lp->mail_pw==NULL) {
 		return 0;
 	}
@@ -862,9 +861,6 @@ int dc_imap_connect(dc_imap_t* imap, const dc_loginparam_t* lp,
 	imap->imap_user    = dc_strdup(lp->mail_user);
 	imap->imap_pw      = dc_strdup(lp->mail_pw);
 	imap->server_flags = lp->server_flags;
-
-	free(imap->watch_folder);
-	imap->watch_folder = dc_strdup(watch_folder);
 
 	if (!setup_handle_if_needed(imap)) {
 		goto cleanup;
@@ -931,6 +927,17 @@ void dc_imap_disconnect(dc_imap_t* imap)
 int dc_imap_is_connected(const dc_imap_t* imap)
 {
 	return (imap && imap->connected);
+}
+
+
+void dc_imap_set_watch_folder(dc_imap_t* imap, const char* watch_folder)
+{
+	if (imap==NULL || watch_folder==NULL) {
+		return;
+	}
+
+	free(imap->watch_folder);
+	imap->watch_folder = dc_strdup(watch_folder);
 }
 
 

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -43,7 +43,8 @@ typedef struct dc_imap_t
 	int                   should_reconnect;
 
 	int                   can_idle;
-	char                  imap_delimiter;/* IMAP Path separator. Set as a side-effect in list_folders__ */
+	int                   has_xlist;
+	char                  imap_delimiter;/* IMAP Path separator. Set as a side-effect during configure() */
 
 	char*                 watch_folder;
 	pthread_cond_t        watch_cond;
@@ -86,6 +87,8 @@ int        dc_imap_markseen_msg      (dc_imap_t*, const char* folder, uint32_t s
 
 int        dc_imap_delete_msg        (dc_imap_t*, const char* rfc724_mid, const char* folder, uint32_t server_uid); /* only returns 0 on connection problems; we should try later again in this case */
 
+void       dc_imap_configure_folders (dc_imap_t*);
+int        dc_imap_is_error          (dc_imap_t* imap, int code);
 
 #ifdef __cplusplus
 } /* /extern "C" */

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -71,7 +71,8 @@ typedef struct dc_imap_t
 dc_imap_t* dc_imap_new               (dc_get_config_t, dc_set_config_t, dc_receive_imf_t, void* userData, dc_context_t*);
 void       dc_imap_unref             (dc_imap_t*);
 
-int        dc_imap_connect           (dc_imap_t*, const dc_loginparam_t*, const char* watch_folder);
+int        dc_imap_connect           (dc_imap_t*, const dc_loginparam_t*);
+void       dc_imap_set_watch_folder  (dc_imap_t*, const char* watch_folder);
 void       dc_imap_disconnect        (dc_imap_t*);
 int        dc_imap_is_connected      (const dc_imap_t*);
 int        dc_imap_fetch             (dc_imap_t*);

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -45,6 +45,7 @@ typedef struct dc_imap_t
 	int                   can_idle;
 	char                  imap_delimiter;/* IMAP Path separator. Set as a side-effect in list_folders__ */
 
+	char*                 watch_folder;
 	pthread_cond_t        watch_cond;
 	pthread_mutex_t       watch_condmutex;
 	int                   watch_condflag;
@@ -69,7 +70,7 @@ typedef struct dc_imap_t
 dc_imap_t* dc_imap_new               (dc_get_config_t, dc_set_config_t, dc_receive_imf_t, void* userData, dc_context_t*);
 void       dc_imap_unref             (dc_imap_t*);
 
-int        dc_imap_connect           (dc_imap_t*, const dc_loginparam_t*);
+int        dc_imap_connect           (dc_imap_t*, const dc_loginparam_t*, const char* watch_folder);
 void       dc_imap_disconnect        (dc_imap_t*);
 int        dc_imap_is_connected      (const dc_imap_t*);
 int        dc_imap_fetch             (dc_imap_t*);

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -10,7 +10,7 @@ extern "C" {
 #define DC_SMTP_THREAD            5000
 
 
-// jobs in the IMAP-thread
+// jobs in the INBOX-thread
 #define DC_JOB_DELETE_MSG_ON_IMAP     110    // low priority ...
 #define DC_JOB_MARKSEEN_MDN_ON_IMAP   120
 #define DC_JOB_MARKSEEN_MSG_ON_IMAP   130

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -241,6 +241,10 @@ void            dc_perform_imap_fetch        (dc_context_t*);
 void            dc_perform_imap_idle         (dc_context_t*);
 void            dc_interrupt_imap_idle       (dc_context_t*);
 
+void            dc_perform_mvbox_fetch       (dc_context_t*);
+void            dc_perform_mvbox_idle        (dc_context_t*);
+void            dc_interrupt_mvbox_idle      (dc_context_t*);
+
 void            dc_perform_smtp_jobs         (dc_context_t*);
 void            dc_perform_smtp_idle         (dc_context_t*);
 void            dc_interrupt_smtp_idle       (dc_context_t*);


### PR DESCRIPTION
this pr is about to re-implement the move between the INBOX and the DeltaChat folder, see #422

- [x] add a second thread (MVBOX-thread) that watches the DeltaChat folder
- [x] expose the api to set different folders for different threads 
- [x] make the old INBOX-thread folder configurable
- [x] find out the correct MVBOX- resp. DeltaChat-folder during configure - depending on the server, eg. only one of INBOX/DeltaChat or DeltaChat is allowed ... IMAP :/
- [x] make sure, the MVBOX-folder is also set for already configured accounts (upgrades from f-droid)
- [x] use the MVBOX-folder
- [x] make the use of MVBOX optional to allow a pure-dedicated account as just now
- [x] make sure, calling dc_perform_mvbox*() is fine if the MVBOX is disabled (might be hard for the ui to not call these functions, which, however, would be the best)
- [x] markseen() etc. is always called as a job in the INBOX thread - make sure this works also with messages in the DeltaChat folder (should be  - a SELECT is needed for various reasons anyway and the folder as such is known - be we should check this carefully)
- [ ] add functionality to move messages from INBOX to MVBOX (see #475 for a discussion about the timing)
- [ ] _carefully_ decide on the criterions about when to move

we should also consider implementing #408 (check message-id before downloading) as moving between two watched folders results in threads waking up and some additional traffic.