### PR TITLE
move messages from INBOX to MVBOX

### DIFF
--- a/deltachat-core.cbp
+++ b/deltachat-core.cbp
@@ -488,6 +488,9 @@
 		<Unit filename="src/dc_mimeparser.c">
 			<Option compilerVar="CC" />
 		</Unit>
+		<Unit filename="src/dc_move.c">
+			<Option compilerVar="CC" />
+		</Unit>
 		<Unit filename="src/dc_msg.c">
 			<Option compilerVar="CC" />
 		</Unit>

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -489,8 +489,8 @@ void dc_imap_configure_folders(dc_imap_t* imap)
 
 	dc_log_info(imap->context, 0, "Configuring IMAP-folders.");
 
-	mvbox_enabled = dc_sqlite3_get_config_int(imap->context->sql,
-		"mvbox_enabled", DC_MVBOX_DEFAULT_ENABLED);
+	mvbox_enabled = dc_sqlite3_get_config_int(imap->context->sql, "mvbox_watch", DC_MVBOX_WATCH_DEFAULT)
+	             || dc_sqlite3_get_config_int(imap->context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT);
 
 	// this sets imap->imap_delimiter as side-effect
 	folder_list = list_folders(imap);

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -538,7 +538,7 @@ void dc_imap_configure_folders(dc_imap_t* imap)
 	}
 
 	// remember the configuration, mvbox_folder may be NULL
-	dc_sqlite3_set_config_int(imap->context->sql, "configured_mvbox", 1);
+	dc_sqlite3_set_config_int(imap->context->sql, "folders_configured", 1);
 	dc_sqlite3_set_config(imap->context->sql, "configured_mvbox_folder", mvbox_folder);
 
 cleanup:

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -32,7 +32,8 @@ static const char* config_keys[] = {
 	,"selfavatar"
 	,"e2ee_enabled"
 	,"mdns_enabled"
-	,"mvbox_enabled"
+	,"mvbox_watch"
+	,"mvbox_move"
 	,"save_mime_headers"
 	,"configured_addr"
 	,"configured_mail_server"
@@ -113,8 +114,9 @@ static int cb_precheck_imf(dc_imap_t* imap, const char* rfc724_mid,
 		if (old_server_folder[0]==0 && old_server_uid==0
 		 && dc_is_inbox(imap->context, server_folder)) {
 			// bcc-self message that should be marked as seen and moved away
+			// (every other messages have folder/uid set)
 			dc_param_t* param = dc_param_new();
-			if (dc_get_config(imap->context, "mvbox_enabled")) {
+			if (dc_sqlite3_get_config_int(imap->context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT)==0) {
 				dc_param_set_int(param, DC_PARAM_ALSO_MOVE, 1);
 			}
 			dc_job_add(imap->context, DC_JOB_MARKSEEN_MSG_ON_IMAP, msg_id,
@@ -487,11 +489,11 @@ static char* get_sys_config_str(const char* key)
  * - `e2ee_enabled` = 0=no end-to-end-encryption, 1=prefer end-to-end-encryption (default)
  * - `mdns_enabled` = 0=do not send or request read receipts,
  *                    1=send and request read receipts (default)
- * - `mvbox_enabled`= 1=move chat-messages to the `DeltaChat`-folder
- *                    and also watch this folder for changes (default),
+ * - `mvbox_watch`  = 1=watch `DeltaChat`-folder for changes (default),
+ *                    0=do not watch the `DeltaChat`-folder
+ * - `mvbox_move`   = 1=heuristically detect chat-messages
+ *                    and move them to the `DeltaChat`-folder,
  *                    0=do not move chat-messages
- *                    and do not watch the `DeltaChat`-folder.
- *                    Changing this value requires a reconfigure.
  * - `save_mime_headers` = 1=save mime headers and make dc_get_mime_headers() work for subsequent calls,
  *                    0=do not save mime headers (default)
  *
@@ -587,8 +589,11 @@ char* dc_get_config(dc_context_t* context, const char* key)
 		else if (strcmp(key, "imap_folder")==0) {
 			value = dc_strdup("INBOX");
 		}
-		else if (strcmp(key, "mvbox_enabled")==0) {
-			value = dc_mprintf("%i", DC_MVBOX_DEFAULT_ENABLED);
+		else if (strcmp(key, "mvbox_watch")==0) {
+			value = dc_mprintf("%i", DC_MVBOX_WATCH_DEFAULT);
+		}
+		else if (strcmp(key, "mvbox_move")==0) {
+			value = dc_mprintf("%i", DC_MVBOX_MOVE_DEFAULT);
 		}
 		else {
 			value = dc_mprintf("");
@@ -644,7 +649,8 @@ char* dc_get_info(dc_context_t* context)
 	char*            fingerprint_str = NULL;
 	dc_loginparam_t* l = NULL;
 	dc_loginparam_t* l2 = NULL;
-	int              mvbox_enabled = 0;
+	int              mvbox_watch = 0;
+	int              mvbox_move = 0;
 	int              configured_mvbox = 0;
 	char*            configured_mvbox_folder = NULL;
 	int              contacts = 0;
@@ -705,7 +711,8 @@ char* dc_get_info(dc_context_t* context)
 	l_readable_str = dc_loginparam_get_readable(l);
 	l2_readable_str = dc_loginparam_get_readable(l2);
 
-	mvbox_enabled = dc_sqlite3_get_config_int(context->sql, "mvbox_enabled", DC_MVBOX_DEFAULT_ENABLED);
+	mvbox_watch = dc_sqlite3_get_config_int(context->sql, "mvbox_watch", DC_MVBOX_WATCH_DEFAULT);
+	mvbox_move = dc_sqlite3_get_config_int(context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT);
 	configured_mvbox = dc_sqlite3_get_config_int(context->sql, "configured_mvbox", 0);
 	configured_mvbox_folder = dc_sqlite3_get_config(context->sql, "configured_mvbox_folder", "<unset>");
 
@@ -728,7 +735,8 @@ char* dc_get_info(dc_context_t* context)
 		"is_configured=%i\n"
 		"entered_account_settings=%s\n"
 		"used_account_settings=%s\n"
-		"mvbox_enabled=%i\n"
+		"mvbox_watch=%i\n"
+		"mvbox_move=%i\n"
 		"configured_mvbox=%i\n"
 		"configured_mvbox_folder=%s\n"
 		"mdns_enabled=%i\n"
@@ -754,7 +762,8 @@ char* dc_get_info(dc_context_t* context)
 		, is_configured
 		, l_readable_str
 		, l2_readable_str
-		, mvbox_enabled
+		, mvbox_watch
+		, mvbox_move
 		, configured_mvbox
 		, configured_mvbox_folder
 		, mdns_enabled

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -116,7 +116,7 @@ static int cb_precheck_imf(dc_imap_t* imap, const char* rfc724_mid,
 			// bcc-self message that should be marked as seen and moved away
 			// (every other messages have folder/uid set)
 			dc_param_t* param = dc_param_new();
-			if (dc_sqlite3_get_config_int(imap->context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT)==0) {
+			if (dc_sqlite3_get_config_int(imap->context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT)) {
 				dc_param_set_int(param, DC_PARAM_ALSO_MOVE, 1);
 			}
 			dc_job_add(imap->context, DC_JOB_MARKSEEN_MSG_ON_IMAP, msg_id,

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -651,7 +651,7 @@ char* dc_get_info(dc_context_t* context)
 	dc_loginparam_t* l2 = NULL;
 	int              mvbox_watch = 0;
 	int              mvbox_move = 0;
-	int              configured_mvbox = 0;
+	int              folders_configured = 0;
 	char*            configured_mvbox_folder = NULL;
 	int              contacts = 0;
 	int              chats = 0;
@@ -713,7 +713,7 @@ char* dc_get_info(dc_context_t* context)
 
 	mvbox_watch = dc_sqlite3_get_config_int(context->sql, "mvbox_watch", DC_MVBOX_WATCH_DEFAULT);
 	mvbox_move = dc_sqlite3_get_config_int(context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT);
-	configured_mvbox = dc_sqlite3_get_config_int(context->sql, "configured_mvbox", 0);
+	folders_configured = dc_sqlite3_get_config_int(context->sql, "folders_configured", 0);
 	configured_mvbox_folder = dc_sqlite3_get_config(context->sql, "configured_mvbox_folder", "<unset>");
 
 	temp = dc_mprintf(
@@ -737,7 +737,7 @@ char* dc_get_info(dc_context_t* context)
 		"used_account_settings=%s\n"
 		"mvbox_watch=%i\n"
 		"mvbox_move=%i\n"
-		"configured_mvbox=%i\n"
+		"folders_configured=%i\n"
 		"configured_mvbox_folder=%s\n"
 		"mdns_enabled=%i\n"
 		"e2ee_enabled=%i\n"
@@ -764,7 +764,7 @@ char* dc_get_info(dc_context_t* context)
 		, l2_readable_str
 		, mvbox_watch
 		, mvbox_move
-		, configured_mvbox
+		, folders_configured
 		, configured_mvbox_folder
 		, mdns_enabled
 		, e2ee_enabled

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -105,6 +105,10 @@ static int cb_precheck_imf(dc_imap_t* imap, const char* rfc724_mid,
 		 || old_server_uid!=server_uid) {
 			dc_update_server_uid(imap->context, rfc724_mid, server_folder, server_uid);
 		}
+
+		// TODO: for self-sent-messages (if old_server_folder is unset?),
+		// we should move the message away to the MVBOX and call
+		// dc_schedule_move() incl. markseen (see #448)
 	}
 
 	free(old_server_folder);

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -103,8 +103,8 @@ void            dc_log_info          (dc_context_t*, int data1, const char* msg,
 
 void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
-int             dc_shall_move        (dc_context_t*, const dc_mimeparser_t* parser, uint32_t msg_id);
-void            dc_schedule_move     (dc_context_t*, uint32_t server_uid, int markread);
+int             dc_shall_move        (dc_context_t*, const char* folder, const dc_mimeparser_t* parser, uint32_t msg_id);
+int             dc_is_inbox          (dc_context_t*, const char* folder);
 
 #define         DC_BAK_PREFIX                "delta-chat"
 #define         DC_BAK_SUFFIX                "bak"

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -103,7 +103,7 @@ void            dc_log_info          (dc_context_t*, int data1, const char* msg,
 
 void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
-int             dc_shall_move        (dc_context_t*, uint32_t msg_id);
+int             dc_shall_move        (dc_context_t*, const dc_mimeparser_t* parser, uint32_t msg_id);
 void            dc_schedule_move     (dc_context_t*, uint32_t server_uid, int markread);
 
 #define         DC_BAK_PREFIX                "delta-chat"

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -121,7 +121,8 @@ int             dc_is_inbox          (dc_context_t*, const char* folder);
 // some defaults
 #define DC_E2EE_DEFAULT_ENABLED   1
 #define DC_MDNS_DEFAULT_ENABLED   1
-#define DC_MVBOX_DEFAULT_ENABLED  1
+#define DC_MVBOX_WATCH_DEFAULT    1
+#define DC_MVBOX_MOVE_DEFAULT     1
 
 
 /* library private: end-to-end-encryption */

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -104,6 +104,14 @@ void            dc_log_info          (dc_context_t*, int data1, const char* msg,
 
 void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
+#define         DC_NOT_CONNECTED     0
+#define         DC_ALREADY_CONNECTED 1
+#define         DC_JUST_CONNECTED    2
+int             dc_connect_to_configured_imap (dc_context_t*, dc_imap_t*);
+
+#define         DC_CREATE_MVBOX      0x01
+void            dc_configure_folders (dc_context_t*, dc_imap_t*, int flags);
+
 int             dc_shall_move        (dc_context_t*, const char* folder, const dc_mimeparser_t* parser, uint32_t msg_id);
 int             dc_is_inbox          (dc_context_t*, const char* folder);
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -103,6 +103,9 @@ void            dc_log_info          (dc_context_t*, int data1, const char* msg,
 
 void            dc_receive_imf       (dc_context_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
+int             dc_shall_move        (dc_context_t*, uint32_t msg_id);
+void            dc_schedule_move     (dc_context_t*, uint32_t server_uid, int markread);
+
 #define         DC_BAK_PREFIX                "delta-chat"
 #define         DC_BAK_SUFFIX                "bak"
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -56,6 +56,7 @@ struct _dc_context
 	pthread_cond_t   mvboxidle_cond;
 	pthread_mutex_t  mvboxidle_condmutex;
 	int              mvboxidle_condflag;
+	int              perform_mvbox_jobs_needed;
 	int              mvbox_suspended;
 	int              mvbox_using_handle;
 

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -1122,6 +1122,8 @@ dc_imap_res dc_imap_move(dc_imap_t* imap, const char* folder, uint32_t uid,
 		mailimap_set_free(res_setdest);
 	}
 
+	res = DC_SUCCESS;
+
 cleanup:
 	FREE_SET(set);
 	FREE_SET(res_setsrc);
@@ -1154,6 +1156,8 @@ dc_imap_res dc_imap_set_seen(dc_imap_t* imap, const char* folder, uint32_t uid)
 		dc_log_warning(imap->context, 0, "Cannot mark message as seen.");
 		goto cleanup;
 	}
+
+	res = DC_SUCCESS;
 
 cleanup:
 	return res==DC_RETRY_LATER?

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -1079,7 +1079,7 @@ dc_imap_res dc_imap_move(dc_imap_t* imap, const char* folder, uint32_t uid,
 	}
 
     if (strcasecmp(folder, dest_folder)==0) {
-		dc_log_info(imap->context, 0, "Skip movin message; message %s/%i is already in %s...", folder, (int)uid, dest_folder);
+		dc_log_info(imap->context, 0, "Skip moving message; message %s/%i is already in %s...", folder, (int)uid, dest_folder);
 		res = DC_ALREADY_DONE;
 		goto cleanup;
     }

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -12,6 +12,9 @@
 static int  setup_handle_if_needed   (dc_imap_t*);
 static void unsetup_handle           (dc_imap_t*);
 
+#define FREE_SET(a)        if((a)) { mailimap_set_free((a)); }
+#define FREE_FETCH_LIST(a) if((a)) { mailimap_fetch_list_free((a)); }
+
 
 /*******************************************************************************
  * Tools
@@ -1059,20 +1062,80 @@ cleanup:
 }
 
 
-int dc_imap_markseen_msg(dc_imap_t* imap, const char* folder, uint32_t server_uid, int ms_flags,
-                        char** ret_server_folder, uint32_t* ret_server_uid, int* ret_ms_flags)
+dc_imap_res dc_imap_move(dc_imap_t* imap, const char* folder, uint32_t uid,
+                         const char* dest_folder, uint32_t* dest_uid)
 {
-	// when marking as seen, there is no real need to check against the rfc724_mid - in the worst case, when the UID validity or the mailbox has changed, we mark the wrong message as "seen" - as the very most messages are seen, this is no big thing.
-	// command would be "STORE 123,456,678 +FLAGS (\Seen)"
+	dc_imap_res          res = DC_RETRY_LATER;
 	int                  r = 0;
-	struct mailimap_set* set = NULL;
+	struct mailimap_set* set = mailimap_set_new_single(uid);
+	uint32_t             res_uid = 0;
+	struct mailimap_set* res_setsrc = NULL;
+	struct mailimap_set* res_setdest = NULL;
 
-	if (imap==NULL || folder==NULL || server_uid==0 || ret_server_folder==NULL || ret_server_uid==NULL || ret_ms_flags==NULL
-	 || *ret_server_folder!=NULL || *ret_server_uid!=0 || *ret_ms_flags!=0) {
-		return 1; /* job done */
+	if (imap==NULL || folder==NULL || uid==0
+	 || dest_folder==NULL || dest_uid==NULL || set==NULL) {
+		res = DC_FAILED;
+		goto cleanup;
 	}
 
-	if ((set=mailimap_set_new_single(server_uid))==NULL) {
+    if (strcasecmp(folder, dest_folder)==0) {
+		dc_log_info(imap->context, 0, "Skip movin message; message %s/%i is already in %s...", folder, (int)uid, dest_folder);
+		res = DC_ALREADY_DONE;
+		goto cleanup;
+    }
+
+	dc_log_info(imap->context, 0, "Moving message %s/%i to %s...", folder, (int)uid, dest_folder);
+
+	if (select_folder(imap, folder)==0) {
+		dc_log_warning(imap->context, 0, "Cannot select folder.");
+		goto cleanup;
+	}
+
+	/* TODO/TOCHECK: UIDPLUS extension may not be supported on servers;
+	if in doubt, we can find out the resulting UID using "imap_selection_info->sel_uidnext" then */
+
+	r = mailimap_uidplus_uid_move(imap->etpan, set, dest_folder, &res_uid, &res_setsrc, &res_setdest);
+	if (dc_imap_is_error(imap, r)) {
+		dc_log_info(imap->context, 0, "Cannot move message, fallback to COPY/DELETE %s/%i to %s...", folder, (int)uid, dest_folder);
+		r = mailimap_uidplus_uid_copy(imap->etpan, set, dest_folder, &res_uid, &res_setsrc, &res_setdest);
+		if (dc_imap_is_error(imap, r)) {
+			dc_log_info(imap->context, 0, "Cannot copy message.");
+			goto cleanup;
+		}
+		else {
+			if (add_flag(imap, uid, mailimap_flag_new_deleted())==0) {
+				dc_log_warning(imap->context, 0, "Cannot mark message as \"Deleted\".");
+			}
+
+			// force an EXPUNGE resp. CLOSE for the selected folder
+			imap->selected_folder_needs_expunge = 1;
+		}
+	}
+
+	if (res_setdest) {
+		clistiter* cur = clist_begin(res_setdest->set_list);
+		if (cur!=NULL) {
+			struct mailimap_set_item* item;
+			item = clist_content(cur);
+			*dest_uid = item->set_first;
+		}
+		mailimap_set_free(res_setdest);
+	}
+
+cleanup:
+	FREE_SET(set);
+	FREE_SET(res_setsrc);
+	return res==DC_RETRY_LATER?
+		(imap->should_reconnect? DC_RETRY_LATER : DC_FAILED) : res;
+}
+
+
+dc_imap_res dc_imap_set_seen(dc_imap_t* imap, const char* folder, uint32_t uid)
+{
+	dc_imap_res res = DC_RETRY_LATER;
+
+	if (imap==NULL || folder==NULL || uid==0) {
+		res = DC_FAILED;
 		goto cleanup;
 	}
 
@@ -1080,26 +1143,53 @@ int dc_imap_markseen_msg(dc_imap_t* imap, const char* folder, uint32_t server_ui
 		goto cleanup;
 	}
 
-	dc_log_info(imap->context, 0, "Marking message %s/%i as seen...", folder, (int)server_uid);
+	dc_log_info(imap->context, 0, "Marking message %s/%i as seen...", folder, (int)uid);
 
 	if (select_folder(imap, folder)==0) {
 		dc_log_warning(imap->context, 0, "Cannot select folder.");
 		goto cleanup;
 	}
 
-	if (add_flag(imap, server_uid, mailimap_flag_new_seen())==0) {
+	if (add_flag(imap, uid, mailimap_flag_new_seen())==0) {
 		dc_log_warning(imap->context, 0, "Cannot mark message as seen.");
 		goto cleanup;
 	}
 
-	dc_log_info(imap->context, 0, "Message marked as seen.");
+cleanup:
+	return res==DC_RETRY_LATER?
+		(imap->should_reconnect? DC_RETRY_LATER : DC_FAILED) : res;
+}
 
-	if ((ms_flags&DC_MS_SET_MDNSent_FLAG)
-	 && imap->etpan->imap_selection_info!=NULL && imap->etpan->imap_selection_info->sel_perm_flags!=NULL)
+
+dc_imap_res dc_imap_set_mdnsent(dc_imap_t* imap, const char* folder, uint32_t uid)
+{
+	// returns 0=job should be retried later, 1=job done, 2=job done and flag just set
+	dc_imap_res          res = DC_RETRY_LATER;
+	struct mailimap_set* set = mailimap_set_new_single(uid);
+	clist*               fetch_result = NULL;
+
+	if (imap==NULL || folder==NULL || uid==0 || set==NULL) {
+		res = DC_FAILED;
+		goto cleanup;
+	}
+
+	if (imap->etpan==NULL) {
+		goto cleanup;
+	}
+
+	dc_log_info(imap->context, 0, "Marking message %s/%i as $MDNSent...", folder, (int)uid);
+
+	if (select_folder(imap, folder)==0) {
+		dc_log_warning(imap->context, 0, "Cannot select folder for $MDNSent.");
+		goto cleanup;
+	}
+
+	/* Check if the folder can handle the `$MDNSent` flag (see RFC 3503).  If so, and not set: set the flags and return this information.
+	If the folder cannot handle the `$MDNSent` flag, we risk duplicated MDNs; it's up to the receiving MUA to handle this then (eg. Delta Chat has no problem with this). */
+	int can_create_flag = 0;
+	if (imap->etpan->imap_selection_info!=NULL
+	 && imap->etpan->imap_selection_info->sel_perm_flags!=NULL)
 	{
-		/* Check if the folder can handle the `$MDNSent` flag (see RFC 3503).  If so, and not set: set the flags and return this information.
-		If the folder cannot handle the `$MDNSent` flag, we risk duplicated MDNs; it's up to the receiving MUA to handle this then (eg. Delta Chat has no problem with this). */
-		int can_create_flag = 0;
 		clistiter* iter;
 		for (iter=clist_begin(imap->etpan->imap_selection_info->sel_perm_flags); iter!=NULL; iter=clist_next(iter))
 		{
@@ -1111,42 +1201,52 @@ int dc_imap_markseen_msg(dc_imap_t* imap, const char* folder, uint32_t server_ui
 				}
 				else if (fp->fl_type==MAILIMAP_FLAG_PERM_FLAG && fp->fl_flag) {
 					struct mailimap_flag* fl = (struct mailimap_flag*)fp->fl_flag;
-					if (fl->fl_type==MAILIMAP_FLAG_KEYWORD && fl->fl_data.fl_keyword && strcmp(fl->fl_data.fl_keyword, "$MDNSent")==0) {
+					if (fl->fl_type==MAILIMAP_FLAG_KEYWORD
+					 && fl->fl_data.fl_keyword
+					 && strcmp(fl->fl_data.fl_keyword, "$MDNSent")==0) {
 						can_create_flag = 1;
 						break;
 					}
 				}
 			}
 		}
+	}
 
-		if (can_create_flag)
-		{
-			clist* fetch_result = NULL;
-			r = mailimap_uid_fetch(imap->etpan, set, imap->fetch_type_flags, &fetch_result);
-			if (!dc_imap_is_error(imap, r) && fetch_result) {
-				clistiter* cur=clist_begin(fetch_result);
-				if (cur) {
-					if (!peek_flag_keyword((struct mailimap_msg_att*)clist_content(cur), "$MDNSent")) {
-						add_flag(imap, server_uid, mailimap_flag_new_flag_keyword(dc_strdup("$MDNSent")));
-						*ret_ms_flags |= DC_MS_MDNSent_JUST_SET;
-					}
-				}
-				mailimap_fetch_list_free(fetch_result);
+	if (can_create_flag)
+	{
+		int r = mailimap_uid_fetch(imap->etpan, set, imap->fetch_type_flags, &fetch_result);
+		if (dc_imap_is_error(imap, r) || fetch_result==NULL) {
+			goto cleanup;
+		}
+
+		clistiter* cur=clist_begin(fetch_result);
+		if (cur==NULL) {
+			goto cleanup;
+		}
+
+		if (peek_flag_keyword((struct mailimap_msg_att*)clist_content(cur), "$MDNSent")) {
+			res = DC_ALREADY_DONE;
+		}
+		else {
+			if (add_flag(imap, uid, mailimap_flag_new_flag_keyword(dc_strdup("$MDNSent")))==0) {
+				goto cleanup;
 			}
-			dc_log_info(imap->context, 0, ((*ret_ms_flags)&DC_MS_MDNSent_JUST_SET)? "$MDNSent just set and MDN will be sent." : "$MDNSent already set and MDN already sent.");
+			res = DC_SUCCESS;
 		}
-		else
-		{
-			*ret_ms_flags |= DC_MS_MDNSent_JUST_SET;
-			dc_log_info(imap->context, 0, "Cannot store $MDNSent flags, risk sending duplicate MDN.");
-		}
+
+		dc_log_info(imap->context, 0, res==DC_SUCCESS? "$MDNSent just set and MDN will be sent." : "$MDNSent already set and MDN already sent.");
+	}
+	else
+	{
+		res = DC_SUCCESS;
+		dc_log_info(imap->context, 0, "Cannot store $MDNSent flags, risk sending duplicate MDN.");
 	}
 
 cleanup:
-	if (set) {
-		mailimap_set_free(set);
-	}
-	return imap->should_reconnect? 0 : 1;
+	FREE_SET(set);
+	FREE_FETCH_LIST(fetch_result);
+	return res==DC_RETRY_LATER?
+		(imap->should_reconnect? DC_RETRY_LATER : DC_FAILED) : res;
 }
 
 

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -72,6 +72,14 @@ typedef struct dc_imap_t
 } dc_imap_t;
 
 
+typedef enum {
+	 DC_FAILED       = 0
+	,DC_RETRY_LATER  = 1
+	,DC_ALREADY_DONE = 2
+	,DC_SUCCESS      = 3
+} dc_imap_res;
+
+
 dc_imap_t* dc_imap_new               (dc_get_config_t, dc_set_config_t,
                                       dc_precheck_imf_t, dc_receive_imf_t,
                                       void* userData, dc_context_t*);
@@ -86,11 +94,10 @@ int        dc_imap_fetch             (dc_imap_t*);
 void       dc_imap_idle              (dc_imap_t*);
 void       dc_imap_interrupt_idle    (dc_imap_t*);
 
-int        dc_imap_append_msg        (dc_imap_t*, time_t timestamp, const char* data_not_terminated, size_t data_bytes, char** ret_server_folder, uint32_t* ret_server_uid);
-
-#define    DC_MS_SET_MDNSent_FLAG   0x02
-#define    DC_MS_MDNSent_JUST_SET   0x10
-int        dc_imap_markseen_msg      (dc_imap_t*, const char* folder, uint32_t server_uid, int ms_flags, char** ret_server_folder, uint32_t* ret_server_uid, int* ret_ms_flags); /* only returns 0 on connection problems; we should try later again in this case */
+dc_imap_res dc_imap_move         (dc_imap_t*, const char* folder, uint32_t uid,
+                                  const char* dest_folder, uint32_t* dest_uid);
+dc_imap_res dc_imap_set_seen     (dc_imap_t*, const char* folder, uint32_t uid);
+dc_imap_res dc_imap_set_mdnsent  (dc_imap_t*, const char* folder, uint32_t uid);
 
 int        dc_imap_delete_msg        (dc_imap_t*, const char* rfc724_mid, const char* folder, uint32_t server_uid); /* only returns 0 on connection problems; we should try later again in this case */
 

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -101,8 +101,8 @@ dc_imap_res dc_imap_set_mdnsent  (dc_imap_t*, const char* folder, uint32_t uid);
 
 int        dc_imap_delete_msg        (dc_imap_t*, const char* rfc724_mid, const char* folder, uint32_t server_uid); /* only returns 0 on connection problems; we should try later again in this case */
 
-void       dc_imap_configure_folders (dc_imap_t*);
 int        dc_imap_is_error          (dc_imap_t* imap, int code);
+
 
 #ifdef __cplusplus
 } /* /extern "C" */

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -79,9 +79,7 @@ static int connect_to_mvbox(dc_context_t* context, int* mvbox_desired)
 
 	*mvbox_desired = 1;
 
-	// a fallback to support upgrades from core 0.29.0 or older;
-	// newer core versions set configured_mvbox_folder during configure.
-	if (dc_sqlite3_get_config_int(context->sql, "configured_mvbox", 0)==0) {
+	if (dc_sqlite3_get_config_int(context->sql, "folders_configured", 0)==0) {
 		if (!(ret_connected=connect_to_imap(context->mvbox))) {
 			goto cleanup;
 		}

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -14,6 +14,7 @@ extern "C" {
 #define DC_JOB_DELETE_MSG_ON_IMAP     110    // low priority ...
 #define DC_JOB_MARKSEEN_MDN_ON_IMAP   120
 #define DC_JOB_MARKSEEN_MSG_ON_IMAP   130
+#define DC_JOB_MOVE_MSG               200
 #define DC_JOB_CONFIGURE_IMAP         900
 #define DC_JOB_IMEX_IMAP              910    // ... high priority
 

--- a/src/dc_move.c
+++ b/src/dc_move.c
@@ -1,0 +1,19 @@
+#include "dc_context.h"
+
+
+int dc_shall_move(dc_context_t* context, uint32_t msg_id)
+{
+	// TODO
+	return 0;
+}
+
+
+/*
+ * Move a message identified by UID from INBOX to MVBOX.
+ * Optionally, messages are also markes as read,
+ * which is useful for self-sended messages and for MDNs.
+ */
+void dc_schedule_move(dc_context_t* context, uint32_t server_uid, int markread)
+{
+	// TODO
+}

--- a/src/dc_move.c
+++ b/src/dc_move.c
@@ -2,18 +2,23 @@
 #include "dc_mimeparser.h"
 
 
-int dc_shall_move(dc_context_t* context, const dc_mimeparser_t* parser, uint32_t msg_id)
+int dc_shall_move(dc_context_t*          context,
+                  const char*            folder,
+                  const dc_mimeparser_t* parser,
+                  uint32_t               msg_id)
 {
-	return parser->is_send_by_messenger;
-}
+	int shall_move = 0;
 
+	if (!dc_is_inbox(context, folder)) {
+		goto cleanup;
+	}
 
-/*
- * Move a message identified by UID from INBOX to MVBOX.
- * Optionally, messages are also markes as read,
- * which is useful for self-sended messages and for MDNs.
- */
-void dc_schedule_move(dc_context_t* context, uint32_t server_uid, int markread)
-{
-	// TODO
+	if (dc_get_config(context, "mvbox_enabled")==0) {
+		goto cleanup;
+	}
+
+	shall_move = parser->is_send_by_messenger;
+
+cleanup:
+	return shall_move;
 }

--- a/src/dc_move.c
+++ b/src/dc_move.c
@@ -1,10 +1,10 @@
 #include "dc_context.h"
+#include "dc_mimeparser.h"
 
 
-int dc_shall_move(dc_context_t* context, uint32_t msg_id)
+int dc_shall_move(dc_context_t* context, const dc_mimeparser_t* parser, uint32_t msg_id)
 {
-	// TODO
-	return 0;
+	return parser->is_send_by_messenger;
 }
 
 

--- a/src/dc_move.c
+++ b/src/dc_move.c
@@ -13,7 +13,7 @@ int dc_shall_move(dc_context_t*          context,
 		goto cleanup;
 	}
 
-	if (dc_get_config(context, "mvbox_enabled")==0) {
+	if (dc_sqlite3_get_config_int(context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT)==0) {
 		goto cleanup;
 	}
 

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1756,7 +1756,7 @@ void dc_markseen_msgs(dc_context_t* context, const uint32_t* msg_ids, int msg_cn
 				if (curr_state==DC_STATE_IN_FRESH || curr_state==DC_STATE_IN_NOTICED) {
 					dc_update_msg_state(context, msg_ids[i], DC_STATE_IN_SEEN);
 					dc_log_info(context, 0, "Seen message #%i.", msg_ids[i]);
-					dc_job_add(context, DC_JOB_MARKSEEN_MSG_ON_IMAP, msg_ids[i], NULL, 0); /* results in a call to dc_markseen_msg_on_imap() */
+					dc_job_add(context, DC_JOB_MARKSEEN_MSG_ON_IMAP, msg_ids[i], NULL, 0);
 					send_event = 1;
 				}
 			}

--- a/src/dc_param.h
+++ b/src/dc_param.h
@@ -40,6 +40,7 @@ typedef struct dc_param_t
 
 #define DC_PARAM_SERVER_FOLDER     'Z'  /* for jobs */
 #define DC_PARAM_SERVER_UID        'z'  /* for jobs */
+#define DC_PARAM_ALSO_MOVE         'M'  /* for jobs */
 
 #define DC_PARAM_UNPROMOTED        'U'  /* for groups */
 #define DC_PARAM_PROFILE_IMAGE     'i'  /* for groups and contacts */

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -1463,7 +1463,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 						dc_param_set(param, DC_PARAM_SERVER_FOLDER, server_folder);
 						dc_param_set_int(param, DC_PARAM_SERVER_UID, server_uid);
 						if (mime_parser->is_send_by_messenger
-						 && dc_sqlite3_get_config_int(context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT)==0) {
+						 && dc_sqlite3_get_config_int(context->sql, "mvbox_move", DC_MVBOX_MOVE_DEFAULT)) {
 							dc_param_set_int(param, DC_PARAM_ALSO_MOVE, 1);
 						}
 						dc_job_add(context, DC_JOB_MARKSEEN_MDN_ON_IMAP, 0, param->packed, 0);

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -930,6 +930,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 	int              state = DC_STATE_UNDEFINED;
 	int              hidden = 0;
 	int              add_delete_job = 0;
+	uint32_t         insert_msg_id = 0;
 
 	sqlite3_stmt*    stmt = NULL;
 	size_t           i = 0;
@@ -1338,7 +1339,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				free(txt_raw);
 				txt_raw = NULL;
 
-				int insert_msg_id = dc_sqlite3_get_rowid(context->sql, "msgs", "rfc724_mid", rfc724_mid);
+				insert_msg_id = dc_sqlite3_get_rowid(context->sql, "msgs", "rfc724_mid", rfc724_mid);
 
 				carray_add(created_db_entries, (void*)(uintptr_t)chat_id, NULL);
 				carray_add(created_db_entries, (void*)(uintptr_t)insert_msg_id, NULL);
@@ -1365,6 +1366,12 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				else {
 					create_event_to_send = DC_EVENT_INCOMING_MSG;
 				}
+			}
+
+			// insert_msg_id is the last msg_id
+			// if the mime-message splits into several delta-messages
+			if (dc_shall_move(context, insert_msg_id)) {
+				dc_schedule_move(context, server_uid, 0);
 			}
 		}
 		else
@@ -1456,6 +1463,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 					otherwise, the moved message get a new server_uid and is "fresh" again and we will be here again to move it away -
 					a classical deadlock, see also (***) in dc_imap.c */
 					if (mime_parser->is_send_by_messenger || mdn_consumed) {
+						// TODO: use dc_schedule_move() instead
 						char* jobparam = dc_mprintf("%c=%s\n%c=%lu", DC_PARAM_SERVER_FOLDER, server_folder, DC_PARAM_SERVER_UID, server_uid);
 							dc_job_add(context, DC_JOB_MARKSEEN_MDN_ON_IMAP, 0, jobparam, 0);
 						free(jobparam);

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -1370,8 +1370,8 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 
 			// insert_msg_id is the last msg_id
 			// if the mime-message splits into several delta-messages
-			if (dc_shall_move(context, mime_parser, insert_msg_id)) {
-				dc_schedule_move(context, server_uid, 0);
+			if (dc_shall_move(context, server_folder, mime_parser, insert_msg_id)) {
+				dc_job_add(context, DC_JOB_MOVE_MSG, insert_msg_id, NULL, 0);
 			}
 		}
 		else

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ lib_src = [
   'dc_keyring.c',
   'dc_loginparam.c',
   'dc_lot.c',
+  'dc_move.c',
   'dc_context.c',
   'dc_configure.c',
   'dc_e2ee.c',


### PR DESCRIPTION
move messages as prototyped in https://github.com/deltachat/playground/blob/master/move_imap/move_imap.py#L150

tackles #422 (support DeltaChat folder) and #448 (mark self-bcc read), successor of #473