### PR TITLE
allow up to three types for a gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ https://github.com/deltachat/deltachat-core/commits/master
 For a high-level overview about changes anywhere in the Delta Chat ecosystem,
 see https://delta.chat/en/changelog
 
+## PENDING
+
+* additional parameter for dc_get_chat_media() to pass a third type
+* additional parameters for dc_get_next_media()
+  to be in sync with dc_get_chat_media()
+
 ## v0.34.0
 
 * re-create goup-member-list if members are missing; avoid group-splits

--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -973,7 +973,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 	else if (strcmp(cmd, "listmedia")==0)
 	{
 		if (sel_chat) {
-			dc_array_t* images = dc_get_chat_media(context, dc_chat_get_id(sel_chat), DC_MSG_IMAGE, DC_MSG_VIDEO);
+			dc_array_t* images = dc_get_chat_media(context, dc_chat_get_id(sel_chat), DC_MSG_IMAGE, DC_MSG_GIF, DC_MSG_VIDEO);
 			int i, icnt = dc_array_get_cnt(images);
 			ret = dc_mprintf("%i images or videos: ", icnt);
 			for (i = 0; i < icnt; i++) {

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -280,8 +280,8 @@ int             dc_get_fresh_msg_cnt         (dc_context_t*, uint32_t chat_id);
 dc_array_t*     dc_get_fresh_msgs            (dc_context_t*);
 void            dc_marknoticed_chat          (dc_context_t*, uint32_t chat_id);
 void            dc_marknoticed_all_chats     (dc_context_t*);
-dc_array_t*     dc_get_chat_media            (dc_context_t*, uint32_t chat_id, int msg_type, int or_msg_type);
-uint32_t        dc_get_next_media            (dc_context_t*, uint32_t curr_msg_id, int dir);
+dc_array_t*     dc_get_chat_media            (dc_context_t*, uint32_t chat_id, int msg_type, int or_msg_type2, int or_msg_type3);
+uint32_t        dc_get_next_media            (dc_context_t*, uint32_t msg_id, int dir, int msg_type, int or_msg_type2, int or_msg_type3);
 
 void            dc_archive_chat              (dc_context_t*, uint32_t chat_id, int archive);
 void            dc_delete_chat               (dc_context_t*, uint32_t chat_id);


### PR DESCRIPTION
this pr changes dc_get_chat_media() so that it takes up to three messages types.

this way a gallery showing  the messages of the types image, gif and video can be implemented more easily.

moreover, dc_get_next_media() is adapted to dc_get_chat_media().