### PR TITLE
set mimetype for outgoing aac files

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2439,6 +2439,13 @@ uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 			}
 			free(better_mime);
 		}
+		else if (!dc_param_exists(msg->param, DC_PARAM_MIMETYPE))
+		{
+			char* better_mime = NULL;
+			dc_msg_guess_msgtype_from_suffix(pathNfilename, NULL, &better_mime);
+			dc_param_set(msg->param, DC_PARAM_MIMETYPE, better_mime);
+			free(better_mime);
+		}
 
 		dc_log_info(context, 0, "Attaching \"%s\" for message type #%i.", pathNfilename, (int)msg->type);
 	}

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -875,6 +875,10 @@ void dc_msg_guess_msgtype_from_suffix(const char* pathNfilename, int* ret_msgtyp
 		*ret_msgtype = DC_MSG_AUDIO;
 		*ret_mime = dc_strdup("audio/mpeg");
 	}
+	else if (strcmp(suffix, "aac")==0) {
+		*ret_msgtype = DC_MSG_AUDIO;
+		*ret_mime = dc_strdup("audio/aac");
+	}
 	else if (strcmp(suffix, "mp4")==0) {
 		*ret_msgtype = DC_MSG_VIDEO;
 		*ret_mime = dc_strdup("video/mp4");


### PR DESCRIPTION
this pr sets the mimetype for outgoing files if not yet done by [dc_msg_set_file()](https://c.delta.chat/classdc__msg__t.html#ae3d4b2a4ed4b10dbe13396ff7739160e).

this is useful if the ui does not set the mimetype but only the file.

Esp. for Voice-Messages in android-dev the mimetype was missing which is also corrected by this pr.