### PR TITLE
Fix builds for mac

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,11 @@ project(
   default_options: ['c_std=gnu99'],
 )
 
+if host_machine.system() == 'darwin'
+  message('Its darwin') 
+endif
+message('Test ' + host_machine.system())
+
 
 ## Figure out the version, use this instead of meson.project_version()
 # The version schema is:
@@ -67,12 +72,27 @@ endif
 # new enough, if not use a static-pic-lib regardless of
 # default-library.
 libetpan_config = find_program('libetpan-config', required: false)
-if (not get_option('monolith')
-    and not get_option('force-etpan-fallback')
-    and libetpan_config.found()
-    and run_command(libetpan_config, ['--version']).stdout().strip()
-                   .version_compare('>=1.8'))
+libetpan_fallback = (get_option('monolith')
+                     or get_option('force-etpan-fallback')
+                     or not libetpan_config.found())
+
+# If we want to use a found etpan version, we have to make sure it's compatible.
+# Sadly libetpan doesn't use the same version accross all platforms, so we have
+# to check this depending on the platform.
+if libetpan_fallback == false
   etpan_version = run_command(libetpan_config, ['--version']).stdout().strip()
+  message('Dependency libetpan found: @0@. Checking for compatibility.'.format(etpan_version))
+  if (etpan_version.version_compare('>=1.8')
+      or host_machine.system() == 'darwin'
+      and etpan_version.version_compare('>=1.6'))
+    message('Check done. Installed libetpan version is compatible.')
+    libetpan_is_compatible = true
+  else
+    error('Check done. Installed libetpan version is NOT compatible. You need at least 1.9 for most platforms or 1.6 for Darwin/Mac')
+  endif
+endif
+
+if libetpan_fallback == false
   etpan_prefix = run_command(libetpan_config, ['--prefix']).stdout().strip()
   etpan_cflags = run_command(libetpan_config, ['--cflags']).stdout().strip().split()
   etpan_libs = run_command(libetpan_config, ['--libs']).stdout().strip().split()
@@ -83,8 +103,8 @@ if (not get_option('monolith')
     include_directories: etpan_inc,
     link_args: etpan_libs,
   )
-  message('Dependency libetpan found: @0@'.format(etpan_version))
 else
+  message('Using libetpan fallback...')
   etpan_proj = subproject('libetpan', default_options: ['static-pic-lib=true'])
   etpan = etpan_proj.get_variable('dep')
 endif

--- a/meson.build
+++ b/meson.build
@@ -7,11 +7,6 @@ project(
   default_options: ['c_std=gnu99'],
 )
 
-if host_machine.system() == 'darwin'
-  message('Its darwin') 
-endif
-message('Test ' + host_machine.system())
-
 
 ## Figure out the version, use this instead of meson.project_version()
 # The version schema is:

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,10 +43,17 @@ lib_src = [
 
 lib_deps = [pthreads, zlib, openssl, sasl, sqlite, etpan, netpgp, math]
 lib_inc = include_directories('.')
+lib_link_args = ''
+
+if host_machine.system() == 'darwin'
+  add_project_link_arguments('-framework','CoreFoundation', '-framework', 'CoreServices', '-framework', 'Security', language: 'c')
+endif
+
 lib = library(
   'deltachat', lib_src,
   dependencies: lib_deps,
   include_directories: lib_inc,
+  link_args: lib_link_args,
   version: version,
   install: true,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,7 +43,6 @@ lib_src = [
 
 lib_deps = [pthreads, zlib, openssl, sasl, sqlite, etpan, netpgp, math]
 lib_inc = include_directories('.')
-lib_link_args = ''
 
 if host_machine.system() == 'darwin'
   add_project_link_arguments('-framework','CoreFoundation', '-framework', 'CoreServices', '-framework', 'Security', language: 'c')
@@ -53,7 +52,6 @@ lib = library(
   'deltachat', lib_src,
   dependencies: lib_deps,
   include_directories: lib_inc,
-  link_args: lib_link_args,
   version: version,
   install: true,
 )


### PR DESCRIPTION
ToDo:
- [x] allow libetpan version 1.6 for mac and don't fall back to bundled etpan
- [x] add -framework flags when linking cmdline @dignifiedquire 

ToDo but not high priority as long as we depend on system installed libetpan:
- [ ] fix bundled etpan to compile on mac (maybe hard, we need to reverse engineer what xcodebuild does and put it into the meson build file). This is needed if we want to build static compiled/monolithy libs for mac at one point. @dignifiedquire 