### PR TITLE
avoid typedef warnings

### DIFF
--- a/src/dc_aheader.h
+++ b/src/dc_aheader.h
@@ -8,15 +8,17 @@ extern "C" {
 #include "dc_key.h"
 
 
+typedef struct _dc_aheader dc_aheader_t;
+
 /**
  * Library-internal. Parse and create [Autocrypt-headers](https://autocrypt.org/en/latest/level1.html#the-autocrypt-header).
  */
-typedef struct dc_aheader_t
+struct _dc_aheader
 {
 	char*          addr;
 	dc_key_t*      public_key; /* != NULL */
 	int            prefer_encrypt; /* YES, NO or NOPREFERENCE if attribute is missing */
-} dc_aheader_t;
+};
 
 
 dc_aheader_t* dc_aheader_new               (); /* the returned pointer is ref'd and must be unref'd after usage */

--- a/src/dc_apeerstate.h
+++ b/src/dc_apeerstate.h
@@ -8,7 +8,8 @@ extern "C" {
 #include "dc_key.h"
 
 
-typedef struct dc_aheader_t dc_aheader_t;
+typedef struct _dc_aheader    dc_aheader_t;
+typedef struct _dc_apeerstate dc_apeerstate_t;
 
 
 #define DC_PE_NOPREFERENCE   0 /* prefer-encrypt states */
@@ -19,7 +20,7 @@ typedef struct dc_aheader_t dc_aheader_t;
 /**
  * Library-internal.
  */
-typedef struct dc_apeerstate_t
+struct _dc_apeerstate
 {
 	/** @privatesection */
 	dc_context_t*  context;
@@ -51,7 +52,7 @@ typedef struct dc_apeerstate_t
 	#define        DC_DE_FINGERPRINT_CHANGED 0x02 // recoverable by a new verify
 	int            degrade_event;
 
-} dc_apeerstate_t;
+};
 
 
 dc_apeerstate_t* dc_apeerstate_new                  (dc_context_t*); /* the returned pointer is ref'd and must be unref'd after usage */

--- a/src/dc_apeerstate.h
+++ b/src/dc_apeerstate.h
@@ -6,9 +6,10 @@ extern "C" {
 
 
 #include "dc_key.h"
+#include "dc_aheader.h"
+#include "dc_hash.h"
 
 
-typedef struct _dc_aheader    dc_aheader_t;
 typedef struct _dc_apeerstate dc_apeerstate_t;
 
 

--- a/src/dc_contact.h
+++ b/src/dc_contact.h
@@ -5,8 +5,8 @@ extern "C" {
 #endif
 
 
-typedef struct dc_sqlite3_t dc_sqlite3_t;
-typedef struct dc_apeerstate_t dc_apeerstate_t;
+typedef struct _dc_sqlite3     dc_sqlite3_t;
+typedef struct _dc_apeerstate  dc_apeerstate_t;
 
 
 /** the structure behind dc_contact_t */

--- a/src/dc_contact.h
+++ b/src/dc_contact.h
@@ -5,8 +5,8 @@ extern "C" {
 #endif
 
 
-typedef struct _dc_sqlite3     dc_sqlite3_t;
-typedef struct _dc_apeerstate  dc_apeerstate_t;
+#include "dc_contact.h"
+#include "dc_apeerstate.h"
 
 
 /** the structure behind dc_contact_t */

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -26,12 +26,12 @@ extern "C" {
 #include "dc_jobthread.h"
 
 
-typedef struct dc_imap_t       dc_imap_t;
-typedef struct dc_smtp_t       dc_smtp_t;
-typedef struct dc_sqlite3_t    dc_sqlite3_t;
-typedef struct dc_job_t        dc_job_t;
-typedef struct dc_mimeparser_t dc_mimeparser_t;
-typedef struct dc_hash_t       dc_hash_t;
+typedef struct _dc_imap        dc_imap_t;
+typedef struct _dc_smtp        dc_smtp_t;
+typedef struct _dc_sqlite3     dc_sqlite3_t;
+typedef struct _dc_job         dc_job_t;
+typedef struct _dc_mimeparser  dc_mimeparser_t;
+typedef struct _dc_hash        dc_hash_t;
 
 
 /** Structure behind dc_context_t */
@@ -138,8 +138,11 @@ int             dc_is_mvbox          (dc_context_t*, const char* folder);
 #define DC_MVBOX_MOVE_DEFAULT     0
 
 
+typedef struct _dc_e2ee_helper dc_e2ee_helper_t;
+
+
 /* library private: end-to-end-encryption */
-typedef struct dc_e2ee_helper_t {
+struct _dc_e2ee_helper {
 	// encryption
 	int        encryption_successfull;
 	void*      cdata_to_free;
@@ -149,7 +152,7 @@ typedef struct dc_e2ee_helper_t {
 	dc_hash_t* signatures; // fingerprints of valid signatures
 	dc_hash_t* gossipped_addr;
 
-} dc_e2ee_helper_t;
+};
 
 void            dc_e2ee_encrypt      (dc_context_t*, const clist* recipients_addr, int force_plaintext, int e2ee_guaranteed, int min_verified, struct mailmime* in_out_message, dc_e2ee_helper_t*);
 void            dc_e2ee_decrypt      (dc_context_t*, struct mailmime* in_out_message, dc_e2ee_helper_t*); /* returns 1 if sth. was decrypted, 0 in other cases */

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -24,14 +24,11 @@ extern "C" {
 #include "dc_msg.h"
 #include "dc_contact.h"
 #include "dc_jobthread.h"
-
-
-typedef struct _dc_imap        dc_imap_t;
-typedef struct _dc_smtp        dc_smtp_t;
-typedef struct _dc_sqlite3     dc_sqlite3_t;
-typedef struct _dc_job         dc_job_t;
-typedef struct _dc_mimeparser  dc_mimeparser_t;
-typedef struct _dc_hash        dc_hash_t;
+#include "dc_imap.h"
+#include "dc_smtp.h"
+#include "dc_job.h"
+#include "dc_mimeparser.h"
+#include "dc_hash.h"
 
 
 /** Structure behind dc_context_t */

--- a/src/dc_hash.h
+++ b/src/dc_hash.h
@@ -8,7 +8,8 @@ extern "C"
 
 /* Forward declarations of structures.
  */
-typedef struct dc_hashelem_t   dc_hashelem_t;
+typedef struct _dc_hash       dc_hash_t;
+typedef struct _dc_hashelem   dc_hashelem_t;
 
 
 /* A complete hash table is an instance of the following structure.
@@ -19,7 +20,7 @@ typedef struct dc_hashelem_t   dc_hashelem_t;
  * accessing this structure are really macros, so we can't really make
  * this structure opaque.
  */
-typedef struct dc_hash_t
+struct _dc_hash
 {
 	char              keyClass;       /* SJHASH_INT, _POINTER, _STRING, _BINARY */
 	char              copyKey;        /* True if copy of key made on insert */
@@ -31,7 +32,7 @@ typedef struct dc_hash_t
 		int           count;          /* Number of entries with this hash */
 		dc_hashelem_t *chain;         /* Pointer to first entry with this hash */
 	} *ht;
-} dc_hash_t;
+};
 
 
 /* Each element in the hash table is an instance of the following
@@ -40,13 +41,13 @@ typedef struct dc_hash_t
  * Again, this structure is intended to be opaque, but it can't really
  * be opaque because it is used by macros.
  */
-typedef struct dc_hashelem_t
+struct _dc_hashelem
 {
 	dc_hashelem_t     *next, *prev;   /* Next and previous elements in the table */
 	void*             data;           /* Data associated with this element */
 	void*             pKey;           /* Key associated with this element */
 	int               nKey;           /* Key associated with this element */
-} dc_hashelem_t;
+};
 
 
 /*

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -10,7 +10,9 @@ extern "C" {
 #endif
 
 
-typedef struct _dc_loginparam dc_loginparam_t;
+#include "dc_loginparam.h"
+
+
 typedef struct _dc_imap       dc_imap_t;
 
 
@@ -23,9 +25,6 @@ typedef int      (*dc_precheck_imf_t)  (dc_imap_t*, const char* rfc724_mid,
 
 #define DC_IMAP_SEEN 0x0001L
 typedef void     (*dc_receive_imf_t)   (dc_imap_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
-
-
-typedef struct _dc_imap dc_imap_t;
 
 
 /**

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 
 
-typedef struct dc_loginparam_t dc_loginparam_t;
-typedef struct dc_imap_t dc_imap_t;
+typedef struct _dc_loginparam dc_loginparam_t;
+typedef struct _dc_imap       dc_imap_t;
 
 
 typedef char*    (*dc_get_config_t)    (dc_imap_t*, const char*, const char*);
@@ -25,10 +25,13 @@ typedef int      (*dc_precheck_imf_t)  (dc_imap_t*, const char* rfc724_mid,
 typedef void     (*dc_receive_imf_t)   (dc_imap_t*, const char* imf_raw_not_terminated, size_t imf_raw_bytes, const char* server_folder, uint32_t server_uid, uint32_t flags);
 
 
+typedef struct _dc_imap dc_imap_t;
+
+
 /**
  * Library-internal.
  */
-typedef struct dc_imap_t
+struct _dc_imap
 {
 	/** @privatesection */
 
@@ -69,7 +72,7 @@ typedef struct dc_imap_t
 	int                   log_connect_errors;
 	int                   skip_log_capabilities;
 
-} dc_imap_t;
+};
 
 
 typedef enum {

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -31,10 +31,12 @@ extern "C" {
 #define DC_SMTP_TIMEOUT_SEC       10
 
 
+typedef struct _dc_job dc_job_t;
+
 /**
  * Library-internal.
  */
-typedef struct dc_job_t
+struct _dc_job
 {
 	/** @privatesection */
 
@@ -48,7 +50,7 @@ typedef struct dc_job_t
 
 	int         try_again;
 	char*       pending_error; // discarded if the retry succeeds
-} dc_job_t;
+};
 
 
 void     dc_job_add                   (dc_context_t*, int action, int foreign_id, const char* param, int delay);

--- a/src/dc_jobthread.h
+++ b/src/dc_jobthread.h
@@ -5,11 +5,11 @@ extern "C" {
 #endif
 
 
-typedef struct _dc_context dc_context_t;
-typedef struct dc_imap_t dc_imap_t;
+typedef struct _dc_imap      dc_imap_t;
+typedef struct _dc_jobthread dc_jobthread_t;
 
 
-typedef struct dc_jobthread_t
+struct _dc_jobthread
 {
 	dc_context_t*    context;
 	char*            name;
@@ -26,7 +26,7 @@ typedef struct dc_jobthread_t
 	int              suspended;
 	int              using_handle;
 
-} dc_jobthread_t;
+};
 
 
 void dc_jobthread_init           (dc_jobthread_t*, dc_context_t* context, const char* name,

--- a/src/dc_jobthread.h
+++ b/src/dc_jobthread.h
@@ -5,7 +5,6 @@ extern "C" {
 #endif
 
 
-typedef struct _dc_imap      dc_imap_t;
 typedef struct _dc_jobthread dc_jobthread_t;
 
 
@@ -15,7 +14,7 @@ struct _dc_jobthread
 	char*            name;
 	char*            folder_config_name;
 
-	dc_imap_t*       imap;
+	struct _dc_imap* imap;
 
 	pthread_mutex_t  mutex;
 

--- a/src/dc_key.h
+++ b/src/dc_key.h
@@ -6,6 +6,7 @@ extern "C" {
 
 
 typedef struct sqlite3_stmt sqlite3_stmt;
+typedef struct _dc_key      dc_key_t;
 
 
 #define DC_KEY_PUBLIC  0
@@ -15,7 +16,7 @@ typedef struct sqlite3_stmt sqlite3_stmt;
 /**
  * Library-internal.
  */
-typedef struct dc_key_t
+struct _dc_key
 {
 	void*          binary;
 	int            bytes;
@@ -23,7 +24,7 @@ typedef struct dc_key_t
 
 	/** @privatesection */
 	int            _m_heap_refcnt; /* !=0 for objects created with dc_key_new(), 0 for stack objects  */
-} dc_key_t;
+};
 
 
 dc_key_t* dc_key_new                      ();

--- a/src/dc_key.h
+++ b/src/dc_key.h
@@ -5,7 +5,9 @@ extern "C" {
 #endif
 
 
-typedef struct sqlite3_stmt sqlite3_stmt;
+#include <sqlite3.h>
+
+
 typedef struct _dc_key      dc_key_t;
 
 

--- a/src/dc_keyring.h
+++ b/src/dc_keyring.h
@@ -5,20 +5,21 @@ extern "C" {
 #endif
 
 
-typedef struct dc_key_t dc_key_t;
+typedef struct _dc_key     dc_key_t;
+typedef struct _dc_keyring dc_keyring_t;
 
 
 /**
  * Library-internal.
  */
-typedef struct dc_keyring_t
+struct _dc_keyring
 {
 	/** @privatesection */
 
 	dc_key_t** keys; /**< Keys in the keyring. Only pointers to keys, the caller is responsible for freeing them and should make sure, the pointers are valid as long as the keyring is valid. */
 	int        count;
 	int        allocated;
-} dc_keyring_t;
+};
 
 dc_keyring_t* dc_keyring_new  ();
 void          dc_keyring_unref();

--- a/src/dc_keyring.h
+++ b/src/dc_keyring.h
@@ -5,7 +5,9 @@ extern "C" {
 #endif
 
 
-typedef struct _dc_key     dc_key_t;
+#include "dc_key.h"
+
+
 typedef struct _dc_keyring dc_keyring_t;
 
 

--- a/src/dc_loginparam.h
+++ b/src/dc_loginparam.h
@@ -5,10 +5,13 @@ extern "C" {
 #endif
 
 
+typedef struct _dc_loginparam dc_loginparam_t;
+
+
 /**
  * Library-internal.
  */
-typedef struct dc_loginparam_t
+struct _dc_loginparam
 {
 	/**  @privatesection */
 
@@ -27,7 +30,7 @@ typedef struct dc_loginparam_t
 
 	/* Server options as DC_LP_* flags */
 	int           server_flags;
-} dc_loginparam_t;
+};
 
 
 dc_loginparam_t* dc_loginparam_new          ();

--- a/src/dc_mimefactory.h
+++ b/src/dc_mimefactory.h
@@ -5,6 +5,8 @@ extern "C" {
 #endif
 
 
+typedef struct _dc_mimefactory dc_mimefactory_t;
+
 
 #define DC_CMD_GROUPNAME_CHANGED           2
 #define DC_CMD_GROUPIMAGE_CHANGED          3
@@ -24,7 +26,7 @@ typedef enum {
 /**
  * Library-internal.
  */
-typedef struct dc_mimefactory_t {
+struct _dc_mimefactory {
 
 	/** @privatesection */
 
@@ -55,7 +57,7 @@ typedef struct dc_mimefactory_t {
 	/* private */
 	dc_context_t* context;
 
-} dc_mimefactory_t;
+};
 
 
 void        dc_mimefactory_init              (dc_mimefactory_t*, dc_context_t*);

--- a/src/dc_mimeparser.h
+++ b/src/dc_mimeparser.h
@@ -14,10 +14,12 @@ extern "C" {
 #include "dc_param.h"
 
 
-typedef struct dc_e2ee_helper_t dc_e2ee_helper_t;
+typedef struct _dc_e2ee_helper dc_e2ee_helper_t;
+typedef struct _dc_mimepart    dc_mimepart_t;
+typedef struct _dc_mimeparser  dc_mimeparser_t;
 
 
-typedef struct dc_mimepart_t
+struct _dc_mimepart
 {
 	/** @privatesection */
 	int                 type; /*one of DC_MSG_* */
@@ -28,10 +30,10 @@ typedef struct dc_mimepart_t
 	int                 bytes;
 	dc_param_t*          param;
 
-} dc_mimepart_t;
+};
 
 
-typedef struct dc_mimeparser_t
+struct _dc_mimeparser
 {
 	/** @privatesection */
 
@@ -60,7 +62,7 @@ typedef struct dc_mimeparser_t
 
 	int                    is_system_message;
 
-} dc_mimeparser_t;
+};
 
 
 dc_mimeparser_t*  dc_mimeparser_new                    (const char* blobdir, dc_context_t*);

--- a/src/dc_mimeparser.h
+++ b/src/dc_mimeparser.h
@@ -14,7 +14,6 @@ extern "C" {
 #include "dc_param.h"
 
 
-typedef struct _dc_e2ee_helper dc_e2ee_helper_t;
 typedef struct _dc_mimepart    dc_mimepart_t;
 typedef struct _dc_mimeparser  dc_mimeparser_t;
 
@@ -50,7 +49,7 @@ struct _dc_mimeparser
 
 	int                    decrypting_failed; /* set, if there are multipart/encrypted parts left after decryption */
 
-	dc_e2ee_helper_t*      e2ee_helper;
+	struct _dc_e2ee_helper* e2ee_helper;
 
 	const char*            blobdir;
 

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -5,7 +5,9 @@ extern "C" {
 #endif
 
 
-typedef struct _dc_param    dc_param_t;
+#include "dc_param.h"
+
+
 typedef struct sqlite3_stmt sqlite3_stmt;
 
 

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -5,7 +5,7 @@ extern "C" {
 #endif
 
 
-typedef struct dc_param_t   dc_param_t;
+typedef struct _dc_param    dc_param_t;
 typedef struct sqlite3_stmt sqlite3_stmt;
 
 

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -8,9 +8,6 @@ extern "C" {
 #include "dc_param.h"
 
 
-typedef struct sqlite3_stmt sqlite3_stmt;
-
-
 typedef enum {
      DC_MOVE_STATE_UNDEFINED = 0
 	,DC_MOVE_STATE_PENDING   = 1

--- a/src/dc_param.h
+++ b/src/dc_param.h
@@ -5,6 +5,9 @@ extern "C" {
 #endif
 
 
+typedef struct _dc_param dc_param_t;
+
+
 /**
  * An object for handling key=value parameter lists; for the key, curently only
  * a single character is allowed.
@@ -14,11 +17,11 @@ extern "C" {
  *
  * Only for library-internal use.
  */
-typedef struct dc_param_t
+struct _dc_param
 {
 	/** @privatesection */
 	char*           packed;    /**< Always set, never NULL. */
-} dc_param_t;
+};
 
 
 #define DC_PARAM_FILE              'f'  /* for msgs */

--- a/src/dc_pgp.h
+++ b/src/dc_pgp.h
@@ -7,8 +7,8 @@ extern "C" {
 
 /*** library-private **********************************************************/
 
-typedef struct dc_key_t dc_key_t;
-typedef struct dc_keyring_t dc_keyring_t;
+typedef struct _dc_key     dc_key_t;
+typedef struct _dc_keyring dc_keyring_t;
 
 
 /* validation errors */

--- a/src/dc_pgp.h
+++ b/src/dc_pgp.h
@@ -7,8 +7,8 @@ extern "C" {
 
 /*** library-private **********************************************************/
 
-typedef struct _dc_key     dc_key_t;
-typedef struct _dc_keyring dc_keyring_t;
+#include "dc_key.h"
+#include "dc_keyring.h"
 
 
 /* validation errors */

--- a/src/dc_saxparser.h
+++ b/src/dc_saxparser.h
@@ -5,18 +5,21 @@ extern "C" {
 #endif
 
 
+typedef struct _dc_saxparser dc_saxparser_t;
+
+
 typedef void (*dc_saxparser_starttag_cb_t) (void* userdata, const char* tag, char** attr);
 typedef void (*dc_saxparser_endtag_cb_t)   (void* userdata, const char* tag);
 typedef void (*dc_saxparser_text_cb_t)     (void* userdata, const char* text, int len); /* len is only informational, text is already null-terminated */
 
 
-typedef struct dc_saxparser_t
+struct _dc_saxparser
 {
 	dc_saxparser_starttag_cb_t starttag_cb;
 	dc_saxparser_endtag_cb_t   endtag_cb;
 	dc_saxparser_text_cb_t     text_cb;
 	void*                      userdata;
-} dc_saxparser_t;
+};
 
 
 void           dc_saxparser_init             (dc_saxparser_t*, void* userData);

--- a/src/dc_simplify.h
+++ b/src/dc_simplify.h
@@ -7,12 +7,16 @@ extern "C" {
 
 /*** library-private **********************************************************/
 
-typedef struct dc_simplify_t
+
+typedef struct _dc_simplify dc_simplify_t;
+
+
+struct _dc_simplify
 {
 	int is_forwarded;
 	int is_cut_at_begin;
 	int is_cut_at_end;
-} dc_simplify_t;
+};
 
 
 dc_simplify_t* dc_simplify_new           ();

--- a/src/dc_smtp.h
+++ b/src/dc_smtp.h
@@ -10,7 +10,9 @@ extern "C" {
 
 /*** library-private **********************************************************/
 
-typedef struct dc_smtp_t
+typedef struct _dc_smtp dc_smtp_t;
+
+struct _dc_smtp
 {
 	mailsmtp*       etpan;
 	char*           from;
@@ -22,7 +24,7 @@ typedef struct dc_smtp_t
 
 	char*           error;
 	int             error_etpan; // one of the MAILSMTP_ERROR_* codes, eg. MAILSMTP_ERROR_EXCEED_STORAGE_ALLOCATION
-} dc_smtp_t;
+};
 
 dc_smtp_t*   dc_smtp_new          (dc_context_t*);
 void         dc_smtp_unref        (dc_smtp_t*);

--- a/src/dc_sqlite3.h
+++ b/src/dc_sqlite3.h
@@ -12,16 +12,19 @@ extern "C" {
 #include <pthread.h>
 
 
+typedef struct _dc_sqlite3 dc_sqlite3_t;
+
+
 /**
  * Library-internal.
  */
-typedef struct dc_sqlite3_t
+struct _dc_sqlite3
 {
 	/** @privatesection */
 	sqlite3*        cobj;               /**< is the database given as dbfile to Open() */
 	dc_context_t*   context;            /**< used for logging and to acquire wakelocks, there may be N dc_sqlite3_t objects per context! In practise, we use 2 on backup, 1 otherwise. */
 
-} dc_sqlite3_t;
+};
 
 
 dc_sqlite3_t* dc_sqlite3_new              (dc_context_t*);

--- a/src/dc_strbuilder.h
+++ b/src/dc_strbuilder.h
@@ -5,13 +5,16 @@ extern "C" {
 #endif
 
 
-typedef struct dc_strbuilder_t
+typedef struct _dc_strbuilder dc_strbuilder_t;
+
+
+struct _dc_strbuilder
 {
 	char* buf;
 	int   allocated;
 	int   free;
 	char* eos;
-} dc_strbuilder_t;
+};
 
 
 void  dc_strbuilder_init    (dc_strbuilder_t*, int init_bytes);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -366,9 +366,6 @@ uint32_t        dc_join_securejoin           (dc_context_t*, const char* qr);
  * The items of the array are typically IDs.
  * To free an array object, use dc_array_unref().
  */
-typedef struct _dc_array dc_array_t;
-
-
 dc_array_t*      dc_array_new                (dc_context_t*, size_t initsize);
 void             dc_array_empty              (dc_array_t*);
 void             dc_array_unref              (dc_array_t*);
@@ -424,9 +421,6 @@ const uintptr_t* dc_array_get_raw            (const dc_array_t*);
  * Rendering the deaddrop in the described way
  * would not add extra work in the UI then.
  */
-typedef struct _dc_chatlist dc_chatlist_t;
-
-
 dc_chatlist_t*   dc_chatlist_new             (dc_context_t*);
 void             dc_chatlist_empty           (dc_chatlist_t*);
 void             dc_chatlist_unref           (dc_chatlist_t*);
@@ -445,9 +439,6 @@ dc_context_t*    dc_chatlist_get_context     (dc_chatlist_t*);
  * and are not updated on database changes;
  * if you want an update, you have to recreate the object.
  */
-typedef struct _dc_chat dc_chat_t;
-
-
 #define         DC_CHAT_ID_DEADDROP          1 // virtual chat showing all messages belonging to chats flagged with chats.blocked=2
 #define         DC_CHAT_ID_TRASH             3 // messages that should be deleted get this chat_id; the messages are deleted from the working thread later then. This is also needed as rfc724_mid should be preset as long as the message is not deleted on the server (otherwise it is downloaded again)
 #define         DC_CHAT_ID_MSGS_IN_CREATION  4 // a message is just in creation but not yet assigned to a chat (eg. we may need the message ID to set up blobs; this avoids unready message to be sent and shown)
@@ -486,9 +477,6 @@ int             dc_chat_is_verified          (const dc_chat_t*);
  * The message object is not updated.
  * If you want an update, you have to recreate the object.
  */
-typedef struct _dc_msg dc_msg_t;
-
-
 #define         DC_MSG_ID_MARKER1            1
 #define         DC_MSG_ID_DAYMARKER          9
 #define         DC_MSG_ID_LAST_SPECIAL       9
@@ -563,8 +551,6 @@ void            dc_msg_latefiling_mediasize  (dc_msg_t*, int width, int height, 
  * dc_create_contact() or dc_add_address_book())
  * only affect the given-name.
  */
-typedef struct _dc_contact dc_contact_t;
-
 #define         DC_CONTACT_ID_SELF           1
 #define         DC_CONTACT_ID_DEVICE         2
 #define         DC_CONTACT_ID_LAST_SPECIAL   9
@@ -595,9 +581,6 @@ int             dc_contact_is_verified       (dc_contact_t*);
  *
  * NB: _Lot_ is used in the meaning _heap_ here.
  */
-typedef struct _dc_lot dc_lot_t;
-
-
 #define         DC_TEXT1_DRAFT     1
 #define         DC_TEXT1_USERNAME  2
 #define         DC_TEXT1_SELF      3


### PR DESCRIPTION
this pr tries to avoid warnings that may be emmited wrt typedef's

see https://github.com/deltachat/deltachat-node/issues/223

i am not totally sure why the warning appears, however with https://github.com/deltachat/deltachat-core/pull/508/commits/eb25158ed7c6f9f046d0dd1d6e7a0dcdf00c58c1 i've separated strucuture definitions and typedefs (as already done for deltachat.h to allow opaque structures).
maybe this fixes the warning, or, at least make things a bit clearer.

Closes https://github.com/deltachat/deltachat-node/issues/223