### PR TITLE
Initialize f to NULL to make sure it is initialized before cleanup

### DIFF
--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -1381,6 +1381,7 @@ int dc_read_file(dc_context_t* context, const char* pathNfilename, void** buf, s
 {
 	int   success = 0;
 	char* pathNfilename_abs = NULL;
+	FILE* f = NULL;
 
 	if (pathNfilename==NULL || buf==NULL || buf_bytes==NULL) {
 		return 0; /* do not go to cleanup as this would dereference "buf" and "buf_bytes" */
@@ -1393,7 +1394,7 @@ int dc_read_file(dc_context_t* context, const char* pathNfilename, void** buf, s
 		goto cleanup;
 	}
 
-	FILE* f = fopen(pathNfilename_abs, "rb");
+	f = fopen(pathNfilename_abs, "rb");
 	if (f==NULL) { goto cleanup; }
 
 	fseek(f, 0, SEEK_END);


### PR DESCRIPTION
Should fix the following warning:

```
../src/dc_tools.c:1392:6: warning: variable 'f' is used uninitialized whenever 'if' condition is true [-Wsometimes-uninitialized]

        if ((pathNfilename_abs=dc_get_abs_path(context, pathNfilename))==NULL) {

            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../src/dc_tools.c:1414:6: note: uninitialized use occurs here

        if (f) {

            ^

../src/dc_tools.c:1392:2: note: remove the 'if' if its condition is always false

        if ((pathNfilename_abs=dc_get_abs_path(context, pathNfilename))==NULL) {

        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../src/dc_tools.c:1396:2: note: variable 'f' is declared here

        FILE* f = fopen(pathNfilename_abs, "rb");

        ^
```