### PR TITLE
do not show group-member-added-messages as images

### DIFF
--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -661,6 +661,9 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 		else if ((optional_field=dc_mimeparser_lookup_optional_field(mime_parser, "Chat-Group-Member-Added"))!=NULL) {
 			X_MrAddToGrp = optional_field->fld_value;
 			mime_parser->is_system_message = DC_CMD_MEMBER_ADDED_TO_GROUP;
+			if ((optional_field=dc_mimeparser_lookup_optional_field(mime_parser, "Chat-Group-Image"))!=NULL) {
+				X_MrGrpImageChanged = optional_field->fld_value;
+			}
 		}
 		else if ((optional_field=dc_mimeparser_lookup_optional_field(mime_parser, "Chat-Group-Name-Changed"))!=NULL) {
 			X_MrGrpNameChanged = 1;


### PR DESCRIPTION
do not show group-member-added-messages as images when they contain the group-profile-image.

fixes #506