### PR TITLE
do not add the prefix 'Me:' to summaries in the Me-chat

### DIFF
--- a/src/dc_lot.c
+++ b/src/dc_lot.c
@@ -188,7 +188,7 @@ void dc_lot_fill(dc_lot_t* lot, const dc_msg_t* msg, const dc_chat_t* chat, cons
 	}
 	else if (msg->from_id==DC_CONTACT_ID_SELF)
 	{
-		if (dc_msg_is_info(msg)) {
+		if (dc_msg_is_info(msg) || dc_chat_is_self_talk(chat)) {
 			lot->text1 = NULL;
 			lot->text1_meaning = 0;
 		}


### PR DESCRIPTION
in general, we try to keep the summaries short; eg. we add the sender only in group threads and 'Me:' only in normal threads for messages that are not from the chat recipient.

for self-chats, however, the summary was _always_ prefixed by the string 'Me:' which is useless double information as the chat-name is already 'Me'.

this pr removes the prefix from these summaries.

nothing to be adapted in the ui.