### PR TITLE
housekeeping

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -8,6 +8,7 @@ your library */
 #include "../src/dc_apeerstate.h"
 #include "../src/dc_key.h"
 #include "../src/dc_pgp.h"
+#include "../src/dc_sqlite3.h"
 
 
 
@@ -419,6 +420,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"connect\n"
 				"disconnect\n"
 				"maybenetwork\n"
+				"housekeeping\n"
 				"help imex (Import/Export)\n"
 				"==============================Chat commands==\n"
 				"listchats [<query>]\n"
@@ -649,6 +651,11 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 	else if (strcmp(cmd, "maybenetwork")==0)
 	{
 		dc_maybe_network(context);
+		ret = COMMAND_SUCCEEDED;
+	}
+	else if (strcmp(cmd, "housekeeping")==0)
+	{
+		dc_housekeeping(context);
 		ret = COMMAND_SUCCEEDED;
 	}
 

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -1585,6 +1585,9 @@ void dc_delete_chat(dc_context_t* context, uint32_t chat_id)
 
 	context->cb(context, DC_EVENT_MSGS_CHANGED, 0, 0);
 
+	dc_job_kill_action(context, DC_JOB_HOUSEKEEPING);
+	dc_job_add(context, DC_JOB_HOUSEKEEPING, 0, NULL, DC_HOUSEKEEPING_DELAY_SEC);
+
 cleanup:
 	if (pending_transaction) { dc_sqlite3_rollback(context->sql); }
 	dc_chat_unref(obj);

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -575,6 +575,7 @@ static void dc_job_perform(dc_context_t* context, int thread, int probe_network)
 				case DC_JOB_SEND_MDN:             dc_job_do_DC_JOB_SEND_MDN             (context, &job); break;
 				case DC_JOB_CONFIGURE_IMAP:       dc_job_do_DC_JOB_CONFIGURE_IMAP       (context, &job); break;
 				case DC_JOB_IMEX_IMAP:            dc_job_do_DC_JOB_IMEX_IMAP            (context, &job); break;
+				case DC_JOB_HOUSEKEEPING:         dc_housekeeping                       (context);       break;
 			}
 
 			if (job.try_again!=DC_AT_ONCE) {

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -11,7 +11,8 @@ extern "C" {
 
 
 // jobs in the INBOX-thread
-#define DC_JOB_DELETE_MSG_ON_IMAP     110    // low priority ...
+#define DC_JOB_HOUSEKEEPING           105    // low priority ...
+#define DC_JOB_DELETE_MSG_ON_IMAP     110
 #define DC_JOB_MARKSEEN_MDN_ON_IMAP   120
 #define DC_JOB_MARKSEEN_MSG_ON_IMAP   130
 #define DC_JOB_MOVE_MSG               200

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1758,6 +1758,9 @@ void dc_delete_msgs(dc_context_t* context, const uint32_t* msg_ids, int msg_cnt)
 
 	if (msg_cnt) {
 		context->cb(context, DC_EVENT_MSGS_CHANGED, 0, 0);
+
+		dc_job_kill_action(context, DC_JOB_HOUSEKEEPING);
+		dc_job_add(context, DC_JOB_HOUSEKEEPING, 0, NULL, DC_HOUSEKEEPING_DELAY_SEC);
 	}
 }
 

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1724,45 +1724,6 @@ void dc_delete_msg_from_db(dc_context_t* context, uint32_t msg_id)
 	sqlite3_finalize(stmt);
 	stmt = NULL;
 
-	char* pathNfilename = dc_param_get(msg->param, DC_PARAM_FILE, NULL);
-	if (pathNfilename) {
-		if (strncmp("$BLOBDIR", pathNfilename, 8)==0)
-		{
-			char* strLikeFilename = dc_mprintf("%%f=%s%%", pathNfilename);
-			stmt = dc_sqlite3_prepare(context->sql,
-				"SELECT id FROM msgs WHERE type!=? AND param LIKE ?;"); /* if this gets too slow, an index over "type" should help. */
-			sqlite3_bind_int (stmt, 1, DC_MSG_TEXT);
-			sqlite3_bind_text(stmt, 2, strLikeFilename, -1, SQLITE_STATIC);
-			int file_used_by_other_msgs = (sqlite3_step(stmt)==SQLITE_ROW)? 1 : 0;
-			free(strLikeFilename);
-			sqlite3_finalize(stmt);
-			stmt = NULL;
-
-			if (!file_used_by_other_msgs)
-			{
-				dc_delete_file(context, pathNfilename);
-
-				char* increation_file = dc_mprintf("%s.increation", pathNfilename);
-				dc_delete_file(context, increation_file);
-				free(increation_file);
-
-				char* filenameOnly = dc_get_filename(pathNfilename);
-				if (msg->type==DC_MSG_VOICE) {
-					char* waveform_file = dc_mprintf("%s/%s.waveform", context->blobdir, filenameOnly);
-					dc_delete_file(context, waveform_file);
-					free(waveform_file);
-				}
-				else if (msg->type==DC_MSG_VIDEO) {
-					char* preview_file = dc_mprintf("%s/%s-preview.jpg", context->blobdir, filenameOnly);
-					dc_delete_file(context, preview_file);
-					free(preview_file);
-				}
-				free(filenameOnly);
-			}
-		}
-		free(pathNfilename);
-	}
-
 cleanup:
 	sqlite3_finalize(stmt);
 	dc_msg_unref(msg);

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -900,12 +900,12 @@ void dc_housekeeping(dc_context_t* context)
 			continue;
 		}
 
-        if (is_file_in_use(&files_in_use, NULL, name)
-         || is_file_in_use(&files_in_use, ".increation", name)
-         || is_file_in_use(&files_in_use, ".waveform", name)
-         || is_file_in_use(&files_in_use, "-preview.jpg", name)) {
+		if (is_file_in_use(&files_in_use, NULL, name)
+		 || is_file_in_use(&files_in_use, ".increation", name)
+		 || is_file_in_use(&files_in_use, ".waveform", name)
+		 || is_file_in_use(&files_in_use, "-preview.jpg", name)) {
 			continue;
-        }
+		}
 
 		unreferenced_count++;
 

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -861,7 +861,9 @@ void dc_housekeeping(dc_context_t* context)
 
 	/* collect all files in use */
 	maybe_add_from_param(context, &files_in_use,
-		"SELECT param FROM msgs WHERE type!=" DC_STRINGIFY(DC_MSG_TEXT) ";",
+		"SELECT param FROM msgs "
+		" WHERE chat_id!=" DC_STRINGIFY(DC_CHAT_ID_TRASH)
+		"   AND type!=" DC_STRINGIFY(DC_MSG_TEXT) ";",
 		DC_PARAM_FILE);
 
 	maybe_add_from_param(context, &files_in_use,

--- a/src/dc_sqlite3.h
+++ b/src/dc_sqlite3.h
@@ -54,6 +54,7 @@ void          dc_sqlite3_commit           (dc_sqlite3_t*);
 void          dc_sqlite3_rollback         (dc_sqlite3_t*);
 
 /* housekeeping */
+#define       DC_HOUSEKEEPING_DELAY_SEC   10
 void          dc_housekeeping             (dc_context_t*);
 
 

--- a/src/dc_sqlite3.h
+++ b/src/dc_sqlite3.h
@@ -49,9 +49,12 @@ int           dc_sqlite3_table_exists     (dc_sqlite3_t*, const char* name);
 void          dc_sqlite3_log_error        (dc_sqlite3_t*, const char* msg, ...);
 uint32_t      dc_sqlite3_get_rowid        (dc_sqlite3_t*, const char* table, const char* field, const char* value);
 
-void          dc_sqlite3_begin_transaction  (dc_sqlite3_t*);
-void          dc_sqlite3_commit             (dc_sqlite3_t*);
-void          dc_sqlite3_rollback           (dc_sqlite3_t*);
+void          dc_sqlite3_begin_transaction(dc_sqlite3_t*);
+void          dc_sqlite3_commit           (dc_sqlite3_t*);
+void          dc_sqlite3_rollback         (dc_sqlite3_t*);
+
+/* housekeeping */
+void          dc_housekeeping             (dc_context_t*);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
- [x] add function to do housekeeping
- [x] call the function from time to time
- [x] add a method for the ui to add a file that is referenced (needed for andoid staging before a message becomes a draft)
- [x] remove direct deletion on message deletion, this is no longer needed (and did not work eg. on deletion of chats)

btw, all housekeeping is done the core, no need for the ui to do anything.

closes #484