### PR TITLE
cleanup before export

### DIFF
--- a/src/dc_imex.c
+++ b/src/dc_imex.c
@@ -859,6 +859,12 @@ static int export_backup(dc_context_t* context, const char* dir)
 		}
 	}
 
+	/* delete unreferenced files before export */
+	dc_housekeeping(context);
+
+	/* vacuum before export; this fixed failed vacuum's on previous import */
+	dc_sqlite3_execute(context->sql, "VACUUM;");
+
 	/* temporary lock and close the source (we just make a copy of the whole file, this is the fastest and easiest approach) */
 	dc_sqlite3_close(context->sql);
 	closed = 1;


### PR DESCRIPTION
do housekeeping before exporting to avoid exporting files that are no longer needed.
moreover, a sqlite-vacuum is done, just in case that it has failed on import and there is now more memory available.

mitigates #261, as the exported file will by smaller. however, importing still needs up to twice of the size of the database to import.