### PR TITLE
fix crash in imap

### DIFF
--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -486,11 +486,12 @@ static int fetch_from_single_folder(dc_imap_t* imap, const char* folder)
 			read_cnt++;
 			if (!imap->precheck_imf(imap, rfc724_mid, folder, cur_uid)) {
 				if (fetch_single_msg(imap, folder, cur_uid)==0/* 0=try again later*/) {
+					dc_log_info(imap->context, 0, "Read error for message %s from \"%s\", trying over later.", rfc724_mid, folder);
 					read_errors++; // with read_errors, lastseenuid is not written
 				}
 			}
 			else {
-				dc_log_info(imap->context, 0, "Skipping message %s by precheck.", rfc724_mid);
+				dc_log_info(imap->context, 0, "Skipping message %s from \"%s\" by precheck.", rfc724_mid, folder);
 			}
 
 			if (cur_uid > new_lastseenuid) {

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -457,6 +457,7 @@ static int fetch_from_single_folder(dc_imap_t* imap, const char* folder)
 		/* store calculated uidvalidity/lastseenuid */
 		uidvalidity = imap->etpan->imap_selection_info->sel_uidvalidity;
 		set_config_lastseenuid(imap, folder, uidvalidity, lastseenuid);
+		dc_log_info(imap->context, 0, "lastseenuid initialized to %i for %s@%i", (int)lastseenuid, folder, (int)uidvalidity);
 	}
 
 	/* fetch messages with larger UID than the last one seen (`UID FETCH lastseenuid+1:*)`, see RFC 4549 */


### PR DESCRIPTION
the problems was that `mailimap_fetch()` and `mailimap_uid_fetch()` may return a fetch_result != NULL on errors; this fetch_result. although set, is not valid then and must not be freed.

this pr checks if either an error is returned _or_  the fetch_result is NULL - in both cases, we set fetch_result to NULL so that it won't be freed again and regard the action as an error.

closes #527