### PR TITLE
[wip] avoid download old messages

### DIFF
--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -513,6 +513,8 @@ static int fetch_from_single_folder(dc_imap_t* imap, const char* folder)
 	}
 
 	if (!read_errors && new_lastseenuid > 0) {
+		// TODO: it might be better to increase the lastseenuid also on partial errors.
+		// however, this requires to sort the list before going through it above.
 		set_config_lastseenuid(imap, folder, uidvalidity, new_lastseenuid);
 	}
 

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -416,6 +416,13 @@ static int fetch_from_single_folder(dc_imap_t* imap, const char* folder)
 		if (imap->etpan->imap_selection_info->sel_has_exists) {
 			if (imap->etpan->imap_selection_info->sel_exists <= 0) {
 				dc_log_info(imap->context, 0, "Folder \"%s\" is empty.", folder);
+				if(imap->etpan->imap_selection_info->sel_exists==0) {
+					/* set lastseenuid=0 for empty folders.
+					id we do not do this here, we'll miss the first message
+					as we will get in here again and fetch from lastseenuid+1 then */
+					set_config_lastseenuid(imap, folder,
+						imap->etpan->imap_selection_info->sel_uidvalidity, 0);
+				}
 				goto cleanup;
 			}
 			/* `FETCH <message sequence number> (UID)` */

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -461,6 +461,7 @@ static int fetch_from_single_folder(dc_imap_t* imap, const char* folder)
 	}
 
 	/* fetch messages with larger UID than the last one seen (`UID FETCH lastseenuid+1:*)`, see RFC 4549 */
+	/* CAVE: some servers return UID smaller or equal to the requested ones under some circumstances! */
 	set = mailimap_set_new_interval(lastseenuid+1, 0);
 		r = mailimap_uid_fetch(imap->etpan, set, imap->fetch_type_prefetch, &fetch_result);
 	FREE_SET(set);
@@ -481,8 +482,7 @@ static int fetch_from_single_folder(dc_imap_t* imap, const char* folder)
 	{
 		struct mailimap_msg_att* msg_att = (struct mailimap_msg_att*)clist_content(cur); /* mailimap_msg_att is a list of attributes: list is a list of message attributes */
 		uint32_t cur_uid = peek_uid(msg_att);
-		if (cur_uid > 0
-		 && cur_uid!=lastseenuid /* `UID FETCH <lastseenuid+1>:*` may include lastseenuid if "*"==lastseenuid */)
+		if (cur_uid > lastseenuid /* `UID FETCH <lastseenuid+1>:*` may include lastseenuid if "*"==lastseenuid - and also smaller uids may be returned! */)
 		{
 			char* rfc724_mid = unquote_rfc724_mid(peek_rfc724_mid(msg_att));
 


### PR DESCRIPTION
this pr tries to fix some bugs related to the issue of downloading old messages, #156 ( o/ @adbenitez )

- https://github.com/deltachat/deltachat-core/commit/72df919fac4212476e8c2abd17ed5dbca8c11e54 fixes one - afterwards - obvious  bug that sets `lastseenuid` to a smaller value if `FETCH UID lastseenuid+1:*` returns values smaller than lastseenuid+1 - this should not happen, however it _does_. seen eg. on a stato server (cc @Ampli-fier :) 

- https://github.com/deltachat/deltachat-core/pull/533/commits/cd82fccf96f31c203a8d2e51ce4e8d96be536c9a initializes `lastseenuid` correctly if the folder is initially empty

i think, this could fix #156:

- `lastseenuid` can only grow, which is the most important fact. 
- might be that the initialization fails, however, reports i've heard from, downloading old messages not only happens directly on first login. and typically server should return EXISTS and then initializing `lastseeenuid` is rather straight-forward.

i cannot imagine how `lastseenuid` can ever get small (assuming this is the real problem of #156)

@hpk42 @ralphtheninja @Ampli-fier all the magic is in [fetch_from_single_folder()](https://github.com/deltachat/deltachat-core/pull/533/commits/72df919fac4212476e8c2abd17ed5dbca8c11e54#diff-ad076f24bcb0e3eb3458e3c034c1ddf5R380) - i would be glad about any more bug that other eyes detect :)  
otherwise we assume #256 being fixed for now :)