### PR TITLE
disconnect on failed folder configuration

### DIFF
--- a/src/dc_jobthread.c
+++ b/src/dc_jobthread.c
@@ -114,6 +114,7 @@ static int connect_to_imap(dc_jobthread_t* jobthread)
 
 	mvbox_name = dc_sqlite3_get_config(jobthread->context->sql, jobthread->folder_config_name, NULL);
 	if (mvbox_name==NULL) {
+		dc_imap_disconnect(jobthread->imap);
 		ret_connected = DC_NOT_CONNECTED;
 		goto cleanup;
 	}


### PR DESCRIPTION
when the folder configuration fails as eg. no SENT-folder could be figured out, the corresponding function returned state "disconnected", however, in fact, the connection was not disconnected.

this is fixed by this pr.