### PR TITLE
tweak sqlite-errors

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -404,6 +404,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"export-setup\n"
 				"poke [<eml-file>|<folder>|<addr> <key-file>]\n"
 				"reset <flags>\n"
+				"stop\n"
 				"============================================="
 			);
 		}
@@ -615,6 +616,11 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 		else {
 			ret = dc_strdup("ERROR: Argument <bits> missing: 1=jobs, 2=peerstates, 4=private keys, 8=rest but server config");
 		}
+	}
+	else if (strcmp(cmd, "stop")==0)
+	{
+		dc_stop_ongoing_process(context);
+		ret = COMMAND_SUCCEEDED;
 	}
 	else if (strcmp(cmd, "set")==0)
 	{

--- a/src/dc_imex.c
+++ b/src/dc_imex.c
@@ -863,7 +863,7 @@ static int export_backup(dc_context_t* context, const char* dir)
 	dc_housekeeping(context);
 
 	/* vacuum before export; this fixed failed vacuum's on previous import */
-	dc_sqlite3_execute(context->sql, "VACUUM;");
+	dc_sqlite3_try_execute(context->sql, "VACUUM;");
 
 	/* temporary lock and close the source (we just make a copy of the whole file, this is the fastest and easiest approach) */
 	dc_sqlite3_close(context->sql);
@@ -1054,7 +1054,7 @@ static int import_backup(dc_context_t* context, const char* backup_to_import)
 	stmt = 0;
 
 	dc_sqlite3_execute(context->sql, "DROP TABLE backup_blobs;");
-	dc_sqlite3_execute(context->sql, "VACUUM;");
+	dc_sqlite3_try_execute(context->sql, "VACUUM;");
 
 	success = 1;
 

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -32,12 +32,16 @@ safe. However, there are some points to keep in mind:
 void dc_sqlite3_log_error(dc_sqlite3_t* sql, const char* msg_format, ...)
 {
 	char*       msg = NULL;
-	const char* notSetUp = "SQLite object not set up.";
 	va_list     va;
+
 	va_start(va, msg_format);
-		msg = sqlite3_vmprintf(msg_format, va); if (msg==NULL) { dc_log_error(sql->context, 0, "Bad log format string \"%s\".", msg_format); }
-			dc_log_error(sql->context, 0, "%s SQLite says: %s", msg, sql->cobj? sqlite3_errmsg(sql->cobj) : notSetUp);
-		sqlite3_free(msg);
+	msg = sqlite3_vmprintf(msg_format, va);
+
+	dc_log_error(sql->context, 0, "%s SQLite says: %s",
+		msg? msg : "",
+		sql->cobj? sqlite3_errmsg(sql->cobj) : "SQLite object not set up.");
+
+	sqlite3_free(msg);
 	va_end(va);
 }
 

--- a/src/dc_sqlite3.h
+++ b/src/dc_sqlite3.h
@@ -45,6 +45,7 @@ int32_t       dc_sqlite3_get_config_int   (dc_sqlite3_t*, const char* key, int32
 /* tools, these functions are compatible to the corresponding sqlite3_* functions */
 sqlite3_stmt* dc_sqlite3_prepare          (dc_sqlite3_t*, const char* sql); /* the result mus be freed using sqlite3_finalize() */
 int           dc_sqlite3_execute          (dc_sqlite3_t*, const char* sql);
+int           dc_sqlite3_try_execute      (dc_sqlite3_t*, const char* sql);
 int           dc_sqlite3_table_exists     (dc_sqlite3_t*, const char* name);
 void          dc_sqlite3_log_error        (dc_sqlite3_t*, const char* msg, ...);
 uint32_t      dc_sqlite3_get_rowid        (dc_sqlite3_t*, const char* table, const char* field, const char* value);


### PR DESCRIPTION
while normally errors happening in sqlite are shown to the user, this pr stops doing so for the VACUUM command and writes the error only to the log.

the VACUUM command is called eg. after a successful export and the exported file is totally valid also without the VACUUM call. typical reasons fro the VACUUM command are "disk full" esp. on smaller android devices (VACUUM needs up to 3 times the size of the file so chances are good that this fails)

imho, we should not worry too much about this as there are already plans to do the whole export/import without VACUUM at all, #261

closes https://github.com/deltachat/deltachat-android/issues/418