### PR TITLE
avoid group-splits on verification problems

### DIFF
--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -943,6 +943,35 @@ void dc_mimeparser_empty(dc_mimeparser_t* mimeparser)
 }
 
 
+void dc_mimeparser_repl_msg_by_error(dc_mimeparser_t* mimeparser,
+                                     const char* error_msg)
+{
+	dc_mimepart_t* part = NULL;
+	int            i = 0;
+
+	if (mimeparser==NULL || mimeparser->parts==NULL
+	 || carray_count(mimeparser->parts)<=0) {
+		return;
+	}
+
+	// part->raw_msg is unchanged
+	// so that the original message can be retrieved using dc_get_msg_info()
+	part = (dc_mimepart_t*)carray_get(mimeparser->parts, 0);
+	part->type = DC_MSG_TEXT;
+	free(part->msg);
+	part->msg = dc_mprintf(DC_EDITORIAL_OPEN "%s" DC_EDITORIAL_CLOSE, error_msg);
+
+	for (i = 1; i < carray_count(mimeparser->parts); i++) {
+		part = (dc_mimepart_t*)carray_get(mimeparser->parts, i);
+		if (part) {
+			dc_mimepart_unref(part);
+		}
+	}
+
+	carray_set_size(mimeparser->parts, 1);
+}
+
+
 static void do_add_single_part(dc_mimeparser_t* parser, dc_mimepart_t* part)
 {
 	/* add a single part to the list of parts, the parser takes the ownership of the part, so you MUST NOT unref it after calling this function. */

--- a/src/dc_mimeparser.h
+++ b/src/dc_mimeparser.h
@@ -81,7 +81,7 @@ dc_mimepart_t*                 dc_mimeparser_get_last_nonmeta       (dc_mimepars
 #define                        dc_mimeparser_has_nonmeta(a)         (dc_mimeparser_get_last_nonmeta((a))!=NULL)
 int                            dc_mimeparser_is_mailinglist_message (dc_mimeparser_t*);
 int                            dc_mimeparser_sender_equals_recipient(dc_mimeparser_t*);
-
+void                           dc_mimeparser_repl_msg_by_error      (dc_mimeparser_t*, const char* error_msg);
 
 
 /* low-level-tools for working with mailmime structures directly */

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -490,7 +490,8 @@ cleanup:
 
 
 static int check_verified_properties(dc_context_t* context, dc_mimeparser_t* mimeparser,
-                                       uint32_t from_id, const dc_array_t* to_ids)
+                                     uint32_t from_id, const dc_array_t* to_ids,
+                                     char** failure_reason)
 {
 	int              everythings_okay = 0;
 	dc_contact_t*    contact = dc_contact_new(context);
@@ -499,8 +500,12 @@ static int check_verified_properties(dc_context_t* context, dc_mimeparser_t* mim
 	char*            q3 = NULL;
 	sqlite3_stmt*    stmt = NULL;
 
+	#define VERIFY_FAIL(a) \
+		*failure_reason = dc_mprintf("%s. See \"Info\" for details.", (a)); \
+		dc_log_warning(context, 0, *failure_reason);
+
 	if (!dc_contact_load_from_db(contact, context->sql, from_id)) {
-		dc_log_warning(context, 0, "Cannot verifiy group; cannot load contact.");
+		VERIFY_FAIL("Cannot verifiy group; cannot load contact.")
 		goto cleanup;
 	}
 
@@ -512,19 +517,18 @@ static int check_verified_properties(dc_context_t* context, dc_mimeparser_t* mim
 	{
 		if (!dc_apeerstate_load_by_addr(peerstate, context->sql, contact->addr)
 		 || dc_contact_is_verified_ex(contact, peerstate) < DC_BIDIRECT_VERIFIED) {
-			dc_log_warning(context, 0, "Cannot verifiy group; sender is not verified.");
-			goto cleanup;
+			VERIFY_FAIL("The sender of this message is not not verified.")
 		}
 
 		if (!dc_apeerstate_has_verified_key(peerstate, mimeparser->e2ee_helper->signatures)) {
-			dc_log_warning(context, 0, "Cannot verifiy group; message is not signed properly.");
+			VERIFY_FAIL("This message is not signed properly by the sender.")
 			goto cleanup;
 		}
 	}
 
 	// ensure, the message is encrypted
 	if (!mimeparser->e2ee_helper->encrypted) {
-		dc_log_warning(context, 0, "Cannot verifiy group; message is not encrypted properly.");
+		VERIFY_FAIL("This message is not encrypted properly by the sender.")
 		goto cleanup;
 	}
 
@@ -563,7 +567,9 @@ static int check_verified_properties(dc_context_t* context, dc_mimeparser_t* mim
 
 		if (!is_verified)
 		{
-			dc_log_warning(context, 0, "Cannot verifiy group; recipient %s is not gossipped.", to_addr);
+			char* err = dc_mprintf("Recipient %s is not gossipped and cannot be verified.", to_addr);
+			VERIFY_FAIL(err)
+			free(err);
 			goto cleanup;
 		}
 	}
@@ -614,6 +620,7 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 	int           X_MrGrpNameChanged = 0;
 	const char*   X_MrGrpImageChanged = NULL;
 	char*         better_msg = NULL;
+	char*         failure_reason = NULL;
 
 	/* search the grpid in the header */
 	{
@@ -713,14 +720,8 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 	/* check, if we have a chat with this group ID */
 	if ((chat_id=dc_get_chat_id_by_grpid(context, grpid, &chat_id_blocked, &chat_id_verified))!=0) {
 		if (chat_id_verified
-		 && !check_verified_properties(context, mime_parser, from_id, to_ids)) {
-			chat_id          = 0; // force the creation of an unverified ad-hoc group.
-			chat_id_blocked  = 0;
-			chat_id_verified = 0;
-			free(grpid);
-			grpid = NULL;
-			free(grpname);
-			grpname = NULL;
+		 && !check_verified_properties(context, mime_parser, from_id, to_ids, &failure_reason)) {
+			dc_mimeparser_repl_msg_by_error(mime_parser, failure_reason);
 		}
 	}
 
@@ -744,8 +745,9 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 	{
 		int create_verified = 0;
 		if (dc_mimeparser_lookup_field(mime_parser, "Chat-Verified")) {
-			if (check_verified_properties(context, mime_parser, from_id, to_ids)) {
-				create_verified = 1;
+			create_verified = 1;
+			if (!check_verified_properties(context, mime_parser, from_id, to_ids, &failure_reason)) {
+				dc_mimeparser_repl_msg_by_error(mime_parser, failure_reason);
 			}
 		}
 
@@ -868,6 +870,7 @@ cleanup:
 	free(grpname);
 	free(self_addr);
 	free(better_msg);
+	free(failure_reason);
 	if (ret_chat_id)         { *ret_chat_id = chat_id; }
 	if (ret_chat_id_blocked) { *ret_chat_id_blocked = chat_id? chat_id_blocked : 0; }
 }


### PR DESCRIPTION
in verified groups, only encrypted messages encrypted and signed with out-of-band-verified keys are allowed. if a given message does not fulfill these needs, in the past, the message was shown in a parallel ad-hoc group. however, this results in some of ux problems, eg. missing overview, weired titles, and it was not clear what was going wrong.
if someone replies to the splitted group, things get even more worse :)

this pr tries to fix the problem by showing the reason of the problem in the original group; the original message text is only available dc_get_msg_info().
this way, replies go still to the same group and it is more clear who causes the problem and how it can be fixed.

closes #413