### PR TITLE
Add support for the stress test in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,3 +123,7 @@ subdir('src')
 
 # Build the binaries.
 subdir('cmdline')
+
+
+# Finally have some tests
+test('stress test', exe, args: ['--stress'])


### PR DESCRIPTION
Now invoking `ninja test` will run the stress test built into the
command line tool.