### PR TITLE
WIP: changed from *.increation files to a separate dc_prepare_msg() call

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2176,7 +2176,7 @@ cleanup:
 }
 
 
-static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_msg_t* msg, time_t timestamp)
+static uint32_t prepare_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_msg_t* msg, time_t timestamp, int state)
 {
 	char*         parent_rfc724_mid = NULL;
 	char*         parent_references = NULL;
@@ -2339,7 +2339,7 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 	sqlite3_bind_int  (stmt,  4, to_id);
 	sqlite3_bind_int64(stmt,  5, timestamp);
 	sqlite3_bind_int  (stmt,  6, msg->type);
-	sqlite3_bind_int  (stmt,  7, DC_STATE_OUT_PENDING);
+	sqlite3_bind_int  (stmt,  7, state);
 	sqlite3_bind_text (stmt,  8, msg->text? msg->text : "",  -1, SQLITE_STATIC);
 	sqlite3_bind_text (stmt,  9, msg->param->packed, -1, SQLITE_STATIC);
 	sqlite3_bind_int  (stmt, 10, msg->hidden);
@@ -2351,7 +2351,6 @@ static uint32_t send_msg_raw(dc_context_t* context, dc_chat_t* chat, const dc_ms
 	}
 
 	msg_id = dc_sqlite3_get_rowid(context->sql, "msgs", "rfc724_mid", new_rfc724_mid);
-	dc_job_add(context, DC_JOB_SEND_MSG_TO_SMTP, msg_id, NULL, 0);
 
 cleanup:
 	free(parent_rfc724_mid);
@@ -2365,51 +2364,10 @@ cleanup:
 }
 
 
-/**
- * Send a message defined by a dc_msg_t object to a chat.
- *
- * Sends the event #DC_EVENT_MSGS_CHANGED on succcess.
- * However, this does not imply, the message really reached the recipient -
- * sending may be delayed eg. due to network problems. However, from your
- * view, you're done with the message. Sooner or later it will find its way.
- *
- * Example:
- * ~~~
- * dc_msg_t* msg = dc_msg_new(context, DC_MSG_IMAGE);
- * dc_msg_set_file(msg, "/file/to/send.jpg", NULL);
- * dc_send_msg(context, msg);
- * ~~~
- *
- * You can even call this function if the file to be sent is still in creation.
- * For this purpose, create a file with the additional extension `.increation`
- * beside the file to sent. Once you're done with creating the file, delete the
- * increation-file and the message will really be sent.
- * This is useful as the user can already send the next messages while
- * eg. the recoding of a video is not yet finished. Or the user can even forward
- * the message with the file being still in creation to other groups.
- *
- * Files being sent with the increation-method must be placed in the
- * blob directory, see dc_get_blobdir().
- * If the increation-method is not used - which is probably the normal case -
- * the file is copied to the blob directory if it is not yet there.
- *
- * @memberof dc_context_t
- * @param context The context object as returned from dc_context_new().
- * @param chat_id Chat ID to send the message to.
- * @param msg Message object to send to the chat defined by the chat ID.
- *     On succcess, msg_id of the object is set up,
- *     The function does not take ownership of the object,
- *     so you have to free it using dc_msg_unref() as usual.
- * @return The ID of the message that is about being sent.
- */
-uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
+static uint32_t prepare_msg_common(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg, int state)
 {
 	char*      pathNfilename = NULL;
 	dc_chat_t* chat = NULL;
-
-	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || msg==NULL || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
-		return 0;
-	}
 
 	msg->id      = 0;
 	msg->context = context;
@@ -2473,17 +2431,122 @@ uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 
 	chat = dc_chat_new(context);
 	if (dc_chat_load_from_db(chat, chat_id)) {
-		msg->id = send_msg_raw(context, chat, msg, dc_create_smeared_timestamp(context));
-		if (msg->id==0) {
-			goto cleanup; /* error already logged */
-		}
+		msg->id = prepare_msg_raw(context, chat, msg, dc_create_smeared_timestamp(context), state);
+		/* potential error already logged */
 	}
-
-	context->cb(context, DC_EVENT_MSGS_CHANGED, chat_id, msg->id);
 
 cleanup:
 	dc_chat_unref(chat);
 	free(pathNfilename);
+	return msg->id;
+}
+
+
+/**
+ * Prepare a message for sending.
+ *
+ * Call this function if the file to be sent is still in creation.
+ * Once you're done with creating the file, call dc_send_msg() with chat_id of 0
+ * and the message will really be sent.
+ *
+ * This is useful as the user can already send the next messages while
+ * e.g. the recoding of a video is not yet finished. Or the user can even forward
+ * the message with the file being still in creation to other groups.
+ *
+ * Files being sent with the increation-method must be placed in the
+ * blob directory, see dc_get_blobdir().
+ * If the increation-method is not used - which is probably the normal case -
+ * dc_send_msg() copies the file to the blob directory if it is not yet there.
+ *
+ * Example:
+ * ~~~
+ * dc_msg_t* msg = dc_msg_new(context, DC_MSG_VIDEO);
+ * dc_msg_set_file(msg, "/file/to/send.mp4", NULL);
+ * dc_prepare_msg(context, chat_id, msg);
+ * // ... after /file/to/send.mp4 is ready:
+ * dc_send_msg(context, 0, msg);
+ *
+ * @memberof dc_context_t
+ * @param context The context object as returned from dc_context_new().
+ * @param chat_id Chat ID to send the message to.
+ * @param msg Message object to send to the chat defined by the chat ID.
+ *     On succcess, msg_id of the object is set up,
+ *     The function does not take ownership of the object,
+ *     so you have to free it using dc_msg_unref() as usual.
+ * @return The ID of the message that is being prepared.
+ */
+uint32_t dc_prepare_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
+{
+	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || msg==NULL || chat_id<=DC_CHAT_ID_LAST_SPECIAL) {
+		return 0;
+	}
+
+	return prepare_msg_common(context, chat_id, msg, DC_STATE_OUT_PREPARING);
+}
+
+/**
+ * Send a message defined by a dc_msg_t object to a chat.
+ *
+ * Sends the event #DC_EVENT_MSGS_CHANGED on succcess.
+ * However, this does not imply, the message really reached the recipient -
+ * sending may be delayed eg. due to network problems. However, from your
+ * view, you're done with the message. Sooner or later it will find its way.
+ *
+ * Example:
+ * ~~~
+ * dc_msg_t* msg = dc_msg_new(context, DC_MSG_IMAGE);
+ * dc_msg_set_file(msg, "/file/to/send.jpg", NULL);
+ * dc_send_msg(context, chat_id, msg);
+ * ~~~
+ *
+ * You can even call this function if the file to be sent is still in creation.
+ * For this purpose, create a file with the additional extension `.increation`
+ * beside the file to sent. Once you're done with creating the file, delete the
+ * increation-file and the message will really be sent.
+ * This is useful as the user can already send the next messages while
+ * eg. the recoding of a video is not yet finished. Or the user can even forward
+ * the message with the file being still in creation to other groups.
+ *
+ * Files being sent with the increation-method must be placed in the
+ * blob directory, see dc_get_blobdir().
+ * If the increation-method is not used - which is probably the normal case -
+ * the file is copied to the blob directory if it is not yet there.
+ *
+ * @memberof dc_context_t
+ * @param context The context object as returned from dc_context_new().
+ * @param chat_id Chat ID to send the message to.
+ *     If dc_prepare_msg() was called before, this parameter must be 0.
+ * @param msg Message object to send to the chat defined by the chat ID.
+ *     On succcess, msg_id of the object is set up,
+ *     The function does not take ownership of the object,
+ *     so you have to free it using dc_msg_unref() as usual.
+ * @return The ID of the message that is about being sent.
+ */
+uint32_t dc_send_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
+{
+	if (context==NULL || context->magic!=DC_CONTEXT_MAGIC || msg==NULL) {
+		return 0;
+	}
+
+	// automatically prepare normal messages
+	if (chat_id) {
+		if (!prepare_msg_common(context, chat_id, msg, DC_STATE_OUT_PENDING)) {
+			return 0;
+		};
+	}
+	// update message state of separately prepared messages
+	else {
+		sqlite3_stmt* stmt = dc_sqlite3_prepare(context->sql,
+			"UPDATE msgs SET state=" DC_STRINGIFY(DC_STATE_OUT_PENDING)
+			" WHERE id=?;");
+		sqlite3_bind_int(stmt, 1, msg->id);
+		sqlite3_step(stmt);
+		sqlite3_finalize(stmt);
+	}
+
+	dc_job_add(context, DC_JOB_SEND_MSG_TO_SMTP, msg->id, NULL, 0);
+
+	context->cb(context, DC_EVENT_MSGS_CHANGED, chat_id, msg->id);
 	return msg->id;
 }
 
@@ -2623,7 +2686,19 @@ void dc_forward_msgs(dc_context_t* context, const uint32_t* msg_ids, int msg_cnt
 			dc_param_set(msg->param, DC_PARAM_FORCE_PLAINTEXT, NULL);
 			dc_param_set(msg->param, DC_PARAM_CMD, NULL);
 
-			uint32_t new_msg_id = send_msg_raw(context, chat, msg, curr_timestamp++);
+			uint32_t new_msg_id;
+			// PREPARING messages can't be forwarded immediately
+			if (msg->state==DC_STATE_OUT_PREPARING) {
+				if (!dc_param_exists(msg->param, DC_PARAM_FWD_ORIGINAL)) {
+					dc_param_set_int(msg->param, DC_PARAM_FWD_ORIGINAL, src_msg_id);
+				}
+				new_msg_id = prepare_msg_raw(context, chat, msg, curr_timestamp++, msg->state);
+			}
+			else {
+				new_msg_id = prepare_msg_raw(context, chat, msg, curr_timestamp++, msg->state);
+				dc_job_add(context, DC_JOB_SEND_MSG_TO_SMTP, new_msg_id, NULL, 0);
+			}
+
 			carray_add(created_db_entries, (void*)(uintptr_t)chat_id, NULL);
 			carray_add(created_db_entries, (void*)(uintptr_t)new_msg_id, NULL);
 		}

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -189,6 +189,8 @@ int dc_msg_get_viewtype(const dc_msg_t* msg)
  * - DC_STATE_IN_SEEN (16) - Incoming message, really _seen_ by the user. Marked as read on IMAP and MDN may be send. Use dc_markseen_msgs() to mark messages as being seen.
  *
  * Outgoing message states:
+ * - DC_STATE_OUT_PREPARING (21) - For files which need time to be prepared before they can be sent,
+ *   the message enters this state before #DC_STATE_OUT_PENDING.
  * - DC_STATE_OUT_PENDING (20) - The user has send the "send" button but the
  *   message is not yet sent and is pending in some way. Maybe we're offline (no checkmark).
  * - DC_STATE_OUT_FAILED (24) - _Unrecoverable_ error (_recoverable_ errors result in pending messages), you'll receive the event #DC_EVENT_MSG_FAILED.
@@ -1021,41 +1023,24 @@ char* dc_msg_get_summarytext_by_raw(int type, const char* text, dc_param_t* para
 
 
 /**
- * Check if a message is still in creation.  The UI can mark files as being
- * in creation by simply creating a file `<filename>.increation`. If
- * `<filename>` is created completely then, the user should just delete
- * `<filename>.increation`.
+ * Check if a message is still in creation.  A message is in creation between
+ * the calls to dc_prepare_msg() and dc_send_msg().
  *
  * Typically, this is used for videos that are recoded by the UI before
  * they can be sent.
  *
  * @memberof dc_msg_t
  * @param msg The message object
- * @return 1=message is still in creation (`<filename>.increation` exists),
+ * @return 1=message is still in creation (dc_send_msg() was not called yet),
  *     0=message no longer in creation
  */
 int dc_msg_is_increation(const dc_msg_t* msg)
 {
-	int is_increation = 0;
-
 	if (msg==NULL || msg->magic!=DC_MSG_MAGIC || msg->context==NULL) {
 		return 0;
 	}
 
-	if (DC_MSG_NEEDS_ATTACHMENT(msg->type))
-	{
-		char* pathNfilename = dc_param_get(msg->param, DC_PARAM_FILE, NULL);
-		if (pathNfilename) {
-			char* totest = dc_mprintf("%s.increation", pathNfilename);
-			if (dc_file_exist(msg->context, totest)) {
-				is_increation = 1;
-			}
-			free(totest);
-			free(pathNfilename);
-		}
-	}
-
-	return is_increation;
+	return DC_MSG_NEEDS_ATTACHMENT(msg->type) && msg->state==DC_STATE_OUT_PREPARING;
 }
 
 
@@ -1241,7 +1226,7 @@ void dc_update_msg_move_state(dc_context_t* context, const char* rfc724_mid, dc_
 
 
 /**
- * Changes the state of PENDING or DELIVERED messages to DC_STATE_OUT_FAILED.
+ * Changes the state of PREPARING, PENDING or DELIVERED messages to DC_STATE_OUT_FAILED.
  * Moreover, the message error text can be updated.
  * Finally, the given error text is also logged using dc_log_error().
  *
@@ -1256,7 +1241,10 @@ void dc_set_msg_failed(dc_context_t* context, uint32_t msg_id, const char* error
 		goto cleanup;
 	}
 
-	if (DC_STATE_OUT_PENDING==msg->state || DC_STATE_OUT_DELIVERED==msg->state) {
+	if (DC_STATE_OUT_PREPARING==msg->state ||
+	    DC_STATE_OUT_PENDING  ==msg->state ||
+	    DC_STATE_OUT_DELIVERED==msg->state)
+	{
 		msg->state = DC_STATE_OUT_FAILED;
 	}
 
@@ -1530,6 +1518,7 @@ char* dc_get_msg_info(dc_context_t* context, uint32_t msg_id)
 		case DC_STATE_OUT_FAILED:    p = dc_strdup("Failed");          break;
 		case DC_STATE_OUT_MDN_RCVD:  p = dc_strdup("Read");            break;
 		case DC_STATE_OUT_PENDING:   p = dc_strdup("Pending");         break;
+		case DC_STATE_OUT_PREPARING: p = dc_strdup("Preparing");       break;
 		default:                     p = dc_mprintf("%i", msg->state); break;
 	}
 	dc_strbuilder_catf(&ret, "State: %s", p);
@@ -1872,7 +1861,10 @@ int dc_mdn_from_ext(dc_context_t* context, uint32_t from_id, const char* rfc724_
 	sqlite3_finalize(stmt);
 	stmt = NULL;
 
-	if (msg_state!=DC_STATE_OUT_PENDING && msg_state!=DC_STATE_OUT_DELIVERED) {
+	if (msg_state!=DC_STATE_OUT_PREPARING &&
+	    msg_state!=DC_STATE_OUT_PENDING &&
+	    msg_state!=DC_STATE_OUT_DELIVERED)
+	{
 		goto cleanup; /* eg. already marked as MDNS_RCVD. however, it is importent, that the message ID is set above as this will allow the caller eg. to move the message away */
 	}
 

--- a/src/dc_param.h
+++ b/src/dc_param.h
@@ -35,7 +35,8 @@ struct _dc_param
 #define DC_PARAM_ERRONEOUS_E2EE    'e'  /* for msgs: decrypted with validation errors or without mutual set, if neither 'c' nor 'e' are preset, the messages is only transport encrypted */
 #define DC_PARAM_FORCE_PLAINTEXT   'u'  /* for msgs: force unencrypted message, either DC_FP_ADD_AUTOCRYPT_HEADER (1), DC_FP_NO_AUTOCRYPT_HEADER (2) or 0 */
 #define DC_PARAM_WANTS_MDN         'r'  /* for msgs: an incoming message which requestes a MDN (aka read receipt) */
-#define DC_PARAM_FORWARDED         'a'  /* for msgs */
+#define DC_PARAM_FORWARDED         'a'  /* for msgs: 1 on the forwarded original */
+#define DC_PARAM_FWD_ORIGINAL      'o'  /* for msgs: ID of the forwarded original on the forwarded copy */
 #define DC_PARAM_CMD               'S'  /* for msgs */
 #define DC_PARAM_CMD_ARG           'E'  /* for msgs */
 #define DC_PARAM_CMD_ARG2          'F'  /* for msgs */

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -488,6 +488,7 @@ int             dc_chat_is_verified          (const dc_chat_t*);
 #define         DC_STATE_IN_SEEN             16
 #define         DC_STATE_OUT_DRAFT           19
 #define         DC_STATE_OUT_PENDING         20
+#define         DC_STATE_OUT_PREPARING       21
 #define         DC_STATE_OUT_FAILED          24
 #define         DC_STATE_OUT_DELIVERED       26 // to check if a mail was sent, use dc_msg_is_sent()
 #define         DC_STATE_OUT_MDN_RCVD        28


### PR DESCRIPTION
Added a new function `dc_prepare_msg()`. It is called with the same arguments as `dc_send_msg()` before. Then, `dc_send_msg()` is called later with the parameter `chat_id` set to `0` to actually create an SMTP job.

`dc_send_msg()` can still be called with a valid `chat_id` directly, like before.