### PR TITLE
Tell tox to pass LD_LIBRARY_PATH for testing of local code during development

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 commands = pytest -rsXx {posargs:tests}
-passenv = TRAVIS
+passenv = TRAVIS LD_LIBRARY_PATH
 deps = 
     pytest
     pytest-faulthandler


### PR DESCRIPTION
Allows to test locally-built code without installing it in /usr/local first.