### PR TITLE
be more specific about version in X-Mailer header, allow more general suffix

### DIFF
--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -165,11 +165,15 @@ static void cb_receive_imf(dc_imap_t* imap, const char* imf_raw_not_terminated, 
  *     - If not mentioned otherweise, the callback should return 0.
  * @param userdata can be used by the client for any purpuse.  He finds it
  *     later in dc_get_userdata().
- * @param os_name is only for decorative use and is shown eg. in the `X-Mailer:` header
- *     in the form "Delta Chat <version> for <os_name>".
- *     You can give the name of the operating system and/or the used environment here.
- *     It is okay to give NULL, in this case `X-Mailer:` header is set to "Delta Chat <version>".
- * @return A context object with some public members. The object must be passed to the other context functions
+ * @param os_name is only for decorative use
+ *     and is shown eg. in the `X-Mailer:` header
+ *     in the form "Delta Chat Core <version>/<os_name>".
+ *     You can give the name of the app, the operating system,
+ *     the used environment and/or the version here.
+ *     It is okay to give NULL, in this case `X-Mailer:` header
+ *     is set to "Delta Chat Core <version>".
+ * @return A context object with some public members.
+ *     The object must be passed to the other context functions
  *     and must be freed using dc_context_unref() after usage.
  */
 dc_context_t* dc_context_new(dc_callback_t cb, void* userdata, const char* os_name)

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -487,9 +487,9 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 		/* Add a X-Mailer header. This is only informational for debugging and may be removed in the release.
 		We do not rely on this header as it may be removed by MTAs. */
 		mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("X-Mailer"),
-			dc_mprintf("Delta Chat %s%s%s",
+			dc_mprintf("Delta Chat Core %s%s%s",
 			DC_VERSION_STR,
-			factory->context->os_name? " for " : "",
+			factory->context->os_name? "/" : "",
 			factory->context->os_name? factory->context->os_name : "")));
 
 		mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Chat-Version"), strdup("1.0"))); /* mark message as being sent by a messenger */


### PR DESCRIPTION
just a minor change to make things about the X-Mailer header clearer:

- the header always starts with `Delta Chat Core` followed by the version of the core
- optionally, after a slash, system specific name and/or version are added as given to [dc_context_new()](https://c.delta.chat/classdc__context__t.html#a9d0f77a01382745e59492dda8509cf83)

this may result in sth. as `X-Mailer: Delta Chat Core 0.40.0/DC Windows 0.101.0` where the string after the slash is completely configurable while guaranteeing a unique string beginning which may be handy for filtering here and there.

closes https://github.com/deltachat/deltachat-desktop/issues/679
closes https://github.com/deltachat/deltachat-android/issues/730