### PR TITLE
simplify moving of dc messages

### DIFF
--- a/src/dc_move.c
+++ b/src/dc_move.c
@@ -3,133 +3,6 @@
 #include "dc_job.h"
 
 
-static dc_move_state_t determine_next_move_state(dc_context_t* context, const dc_msg_t* msg)
-{
-	// Return the next move state for this message.
-	// Only call this function if the message is pending.
-	// This function works with the DB, does not perform any IMAP commands.
-	dc_move_state_t res = DC_MOVE_STATE_UNDEFINED;
-	dc_msg_t*       newmsg = NULL;
-	dc_hash_t       handled_ids;
-
-	// we remember the Messages-IDs we've looped through to avoid a dead-lock
-	dc_hash_init(&handled_ids, DC_HASH_STRING, DC_HASH_COPY_KEY);
-
-	if (context==NULL || msg==NULL) {
-		goto cleanup;
-	}
-
-	dc_log_info(context, 0, "[move] shall_move %s", msg->rfc724_mid);
-
-	if (!dc_is_inbox(context, msg->server_folder)
-	 && !dc_is_sentbox(context, msg->server_folder)) {
-		dc_log_info(context, 0, "[move] %s neither in INBOX nor in SENTBOX", msg->rfc724_mid);
-		goto cleanup;
-	}
-
-	if (msg->move_state!=DC_MOVE_STATE_PENDING) {
-		dc_log_info(context, 0, "[move] %s is not PENDING, this should not happen", msg->rfc724_mid);
-		goto cleanup;
-	}
-
-	if (dc_is_mvbox(context, msg->server_folder)) {
-		dc_log_info(context, 0, "[move] %s is already in mvbox, next state is STAY", msg->rfc724_mid);
-		res = DC_MOVE_STATE_STAY;
-		goto cleanup;
-	}
-
-	int last_dc_count = 0;
-	while (1)
-	{
-		dc_hash_insert_str(&handled_ids, msg->rfc724_mid, (void*)1);
-
-		last_dc_count = msg->is_dc_message? (last_dc_count + 1) : 0;
-
-		if (msg->in_reply_to==NULL || msg->in_reply_to[0]==0)
-		{
-			dc_log_info(context, 0, "[move] detected thread-start %s message", last_dc_count? "DC" : "CLEAR");
-			if (last_dc_count > 0) {
-				res = DC_MOVE_STATE_MOVING;
-				goto cleanup;
-			}
-			else {
-				res = DC_MOVE_STATE_STAY;
-				goto cleanup;
-			}
-		}
-
-		dc_msg_t* temp = dc_msg_new_load(context,
-			dc_rfc724_mid_exists(context, msg->in_reply_to, NULL, NULL));
-		dc_msg_unref(newmsg); // unref after consuming msg->in_reply_to above
-		newmsg = temp;
-
-		if (newmsg==NULL || newmsg->id==0
-		 || dc_hash_find_str(&handled_ids, newmsg->rfc724_mid))
-		{
-			dc_log_info(context, 0, "[move] failed to fetch from db: %s", msg->in_reply_to);
-			// we don't have the parent message ... maybe because
-			// it hasn't arrived (yet), was deleted or we failed to
-			// scan/fetch it:
-			if (last_dc_count >= 4) {
-				dc_log_info(context, 0, "[move] no thread start found, bug last 4 messages were dc");
-				res = DC_MOVE_STATE_MOVING;
-				goto cleanup;
-			}
-			else {
-				dc_log_info(context, 0, "[move] pending: missing parent, last_dc_count=%i", last_dc_count);
-				res = DC_MOVE_STATE_PENDING;
-				goto cleanup;
-			}
-		}
-		else if (newmsg->move_state==DC_MOVE_STATE_MOVING)
-		{
-			dc_log_info(context, 0, "[move] parent was a moved message"); // and papa was rolling stone.
-			res = DC_MOVE_STATE_MOVING;
-			goto cleanup;
-		}
-		else
-		{
-			msg = newmsg;
-		}
-	}
-
-cleanup:
-	dc_msg_unref(newmsg);
-	dc_hash_clear(&handled_ids);
-	return res;
-}
-
-
-static dc_move_state_t resolve_move_state(dc_context_t* context, dc_msg_t* msg)
-{
-	// Return move-state after this message's next move-state is determined
-	// (i.e. it is not PENDING)
-	if (msg->move_state==DC_MOVE_STATE_PENDING)
-	{
-		switch (determine_next_move_state(context, msg))
-		{
-			case DC_MOVE_STATE_MOVING:
-				dc_job_add(context, DC_JOB_MOVE_MSG, msg->id, NULL, 0);
-				dc_update_msg_move_state(context, msg->rfc724_mid, DC_MOVE_STATE_MOVING);
-				msg->move_state = DC_MOVE_STATE_MOVING;
-				break;
-
-			case DC_MOVE_STATE_STAY:
-				dc_update_msg_move_state(context, msg->rfc724_mid, DC_MOVE_STATE_STAY);
-				msg->move_state = DC_MOVE_STATE_STAY;
-				break;
-
-			default:
-				dc_log_info(context, 0, "[move] PENDING uid=%i message-id=%s in-reply-to=%s",
-					(int)msg->server_uid, msg->rfc724_mid, msg->in_reply_to);
-				break;
-		}
-	}
-
-	return msg->move_state;
-}
-
-
 void dc_do_heuristics_moves(dc_context_t* context, const char* folder, uint32_t msg_id)
 {
 	// for already seen messages, folder may be different from msg->folder
@@ -145,23 +18,15 @@ void dc_do_heuristics_moves(dc_context_t* context, const char* folder, uint32_t 
 	}
 
 	msg = dc_msg_new_load(context, msg_id);
-	if (resolve_move_state(context, msg) != DC_MOVE_STATE_PENDING)
-	{
-		// see if there are pending messages which have a in-reply-to
-		// to our current msg
-		stmt = dc_sqlite3_prepare(context->sql,
-			"SELECT id"
-			" FROM msgs"
-			" WHERE move_state=?"
-			"   AND mime_in_reply_to=?");
-		sqlite3_bind_int (stmt, 1, DC_MOVE_STATE_PENDING);
-		sqlite3_bind_text(stmt, 2, msg->rfc724_mid, -1, SQLITE_STATIC);
-		while (sqlite3_step(stmt)==SQLITE_ROW)
-		{
-			dc_msg_unref(msg);
-			msg = dc_msg_new_load(context, sqlite3_column_int(stmt, 0));
-			resolve_move_state(context, msg);
-		}
+
+	if (dc_is_mvbox(context, folder)) {
+		dc_update_msg_move_state(context, msg->rfc724_mid, DC_MOVE_STATE_STAY);
+		goto cleanup;
+	}
+
+	if (msg->is_dc_message /*1=dc message, 2=reply to dc message*/) {
+		dc_job_add(context, DC_JOB_MOVE_MSG, msg->id, NULL, 0);
+		dc_update_msg_move_state(context, msg->rfc724_mid, DC_MOVE_STATE_MOVING);
 	}
 
 cleanup:

--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -68,7 +68,7 @@ struct _dc_msg
 	char*           in_reply_to;
 	char*           server_folder;          /**< Folder where the message was last seen on the server */
 	uint32_t        server_uid;             /**< UID last seen on the server for this message */
-	int             is_dc_message;          /**< Set to 1 if the message was sent by another messenger. 0 otherwise. */
+	int             is_dc_message;          /**< Set to 1 if the message was sent by another messenger. 2=reply to messenger message. 0 otherwise. */
 	int             starred;                /**< Starred-state of the message. 0=no, 1=yes. */
 	int             chat_blocked;           /**< Internal */
 	dc_param_t*     param;                  /**< Additional paramter for the message. Never a NULL-pointer. It is recommended to use setters and getters instead of accessing this field directly. */

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -177,6 +177,79 @@ static int dc_is_reply_to_known_message(dc_context_t* context, dc_mimeparser_t* 
 
 
 /*******************************************************************************
+ * Check if a message is a reply to any messenger message
+ ******************************************************************************/
+
+
+static int is_msgrmsg_rfc724_mid(dc_context_t* context, const char* rfc724_mid)
+{
+	int is_msgrmsg = 0;
+	if (rfc724_mid) {
+		sqlite3_stmt* stmt = dc_sqlite3_prepare(context->sql,
+			"SELECT id FROM msgs "
+			" WHERE rfc724_mid=? "
+			" AND msgrmsg!=0 "
+			" AND chat_id>" DC_STRINGIFY(DC_CHAT_ID_LAST_SPECIAL) ";");
+		sqlite3_bind_text(stmt, 1, rfc724_mid, -1, SQLITE_STATIC);
+		if (sqlite3_step(stmt)==SQLITE_ROW) {
+			is_msgrmsg = 1;
+		}
+		sqlite3_finalize(stmt);
+	}
+	return is_msgrmsg;
+}
+
+
+static int is_msgrmsg_rfc724_mid_in_list(dc_context_t* context, const clist* mid_list)
+{
+	if (mid_list) {
+		for (clistiter* cur = clist_begin(mid_list); cur!=NULL ; cur=clist_next(cur)) {
+			if (is_msgrmsg_rfc724_mid(context, clist_content(cur))) {
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+
+static int dc_is_reply_to_messenger_message(dc_context_t* context, dc_mimeparser_t* mime_parser)
+{
+	/* function checks, if the message defined by mime_parser references a message send by us from Delta Chat.
+	This is similar to is_reply_to_known_message() but
+	- checks also if any of the referenced IDs are send by a messenger
+	- it is okay, if the referenced messages are moved to trash here
+	- no check for the Chat-* headers (function is only called if it is no messenger message itself) */
+
+	struct mailimf_field* field = NULL;
+	if ((field=dc_mimeparser_lookup_field(mime_parser, "In-Reply-To"))!=NULL
+	 && field->fld_type==MAILIMF_FIELD_IN_REPLY_TO)
+	{
+		struct mailimf_in_reply_to* fld_in_reply_to = field->fld_data.fld_in_reply_to;
+		if (fld_in_reply_to) {
+			if (is_msgrmsg_rfc724_mid_in_list(context, field->fld_data.fld_in_reply_to->mid_list)) {
+				return 1;
+			}
+		}
+	}
+
+	if ((field=dc_mimeparser_lookup_field(mime_parser, "References"))!=NULL
+	 && field->fld_type==MAILIMF_FIELD_REFERENCES)
+	{
+		struct mailimf_references* fld_references = field->fld_data.fld_references;
+		if (fld_references) {
+			if (is_msgrmsg_rfc724_mid_in_list(context, field->fld_data.fld_references->mid_list)) {
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+
+/*******************************************************************************
  * Misc. Tools
  ******************************************************************************/
 
@@ -1244,6 +1317,11 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				}
 			}
 
+			int msgrmsg = mime_parser->is_send_by_messenger; /* 1 or 0 for yes/no */
+			if (msgrmsg==0 && dc_is_reply_to_messenger_message(context, mime_parser)) {
+				msgrmsg = 2; /* 2=no, but is reply to messenger message */
+			}
+
 			/* fine, so far.  now, split the message into simple parts usable as "short messages"
 			and add them to the database (mails sent by other messenger clients should result
 			into only one message; mails sent by other clients may result in several messages (eg. one per attachment)) */
@@ -1281,7 +1359,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				sqlite3_bind_int64(stmt,  9, rcvd_timestamp);
 				sqlite3_bind_int  (stmt, 10, part->type);
 				sqlite3_bind_int  (stmt, 11, state);
-				sqlite3_bind_int  (stmt, 12, mime_parser->is_send_by_messenger);
+				sqlite3_bind_int  (stmt, 12, msgrmsg);
 				sqlite3_bind_text (stmt, 13, part->msg? part->msg : "", -1, SQLITE_STATIC);
 				sqlite3_bind_text (stmt, 14, txt_raw? txt_raw : "", -1, SQLITE_STATIC);
 				sqlite3_bind_text (stmt, 15, part->param->packed, -1, SQLITE_STATIC);


### PR DESCRIPTION
leaving delta chat messages in the inbox to keep threads together seems to scare users more that tearing threads.

this pr moves messages with a `Chat-Version:` header to the DeltaChat folder. moreover, replies to dc messages are moved and the current move_state is tracked so that we can go for more complicated heuristics optionally at a later time.

this should result in a cleaner inbox and we can iterate from there, maybe add an option later or so.

this also mitigates the bcc-self story as these messages should also be moved in all cases and no more self-sent messages stay in the inbox.

this pr partly reverts https://github.com/deltachat/deltachat-core/commit/51bcf16c8c7d961d17eed723369b8a2e009fb784#diff-1d2adc03d043975786fd5caef8655673 and surrounding commits.