### PR TITLE
Add function to mark a message to be force-encrypted or force-unencrypted

### DIFF
--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1094,6 +1094,34 @@ void dc_msg_set_text(dc_msg_t* msg, const char* text)
 
 
 /**
+ * Set if the message is sent out encrypted or unencrypted.
+ * This overwrites the heuristic which automatically desides if a message is encrypted or
+ * unencrypted. If set to encrypted here and encryption is not available later, the message
+ * will not be sent out at all.
+ * This does not alter any information in the database; this may be done by dc_send_msg() later.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @param encrypted 1=force-encrypt the msg, 0=force-unencrypt it
+ * @return None.
+ */
+void dc_msg_set_guarantee_e2ee(dc_msg_t* msg, int encrypted)
+{
+	if (msg==NULL || msg->magic!=DC_MSG_MAGIC) {
+		return;
+	}
+	if (encrypted) {
+		dc_param_set_int(msg->param, DC_PARAM_GUARANTEE_E2EE, 1);
+		dc_param_set_int(msg->param, DC_PARAM_FORCE_PLAINTEXT, 0);
+	}
+	else {
+		dc_param_set_int(msg->param, DC_PARAM_GUARANTEE_E2EE, 0);
+		dc_param_set_int(msg->param, DC_PARAM_FORCE_PLAINTEXT, DC_FP_ADD_AUTOCRYPT_HEADER);
+	}
+}
+
+
+/**
  * Set the file associated with a message object.
  * This does not alter any information in the database
  * nor copy or move the file or checks if the file exist.

--- a/src/dc_msg.c
+++ b/src/dc_msg.c
@@ -1095,7 +1095,7 @@ void dc_msg_set_text(dc_msg_t* msg, const char* text)
 
 /**
  * Set if the message is sent out encrypted or unencrypted.
- * This overwrites the heuristic which automatically desides if a message is encrypted or
+ * This overwrites the heuristic which automatically decides if a message is encrypted or
  * unencrypted. If set to encrypted here and encryption is not available later, the message
  * will not be sent out at all.
  * This does not alter any information in the database; this may be done by dc_send_msg() later.

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -532,6 +532,7 @@ void            dc_msg_set_file               (dc_msg_t*, const char* file, cons
 void            dc_msg_set_dimension          (dc_msg_t*, int width, int height);
 void            dc_msg_set_duration           (dc_msg_t*, int duration);
 void            dc_msg_latefiling_mediasize   (dc_msg_t*, int width, int height, int duration);
+void            dc_msg_set_guarantee_e2ee     (dc_msg_t*, int encrypted);
 
 
 /**


### PR DESCRIPTION
Add function to mark a message to be force-encrypted or force-unencrypted regardless of the heuristic to decide about the encryption.

This is related to [227 in the support forum](https://support.delta.chat/t/force-once-un-encrypted-to-directly-reach-a-classic-mua-after-having-had-a-chat/227) and also loosely related to #343 (I don't quite know what to reference here, because there are also corresponding GitHub issues and forum threads, respectively)

One could also think about extending the send command of the cmdline tool by a second optional parameter which triggers this, if desirable. (?)