### PR TITLE
tone down gossip

### DIFF
--- a/src/dc_apeerstate.c
+++ b/src/dc_apeerstate.c
@@ -197,7 +197,7 @@ int dc_apeerstate_save_to_db(const dc_apeerstate_t* peerstate, dc_sqlite3_t* sql
 		stmt = NULL;
 	}
 
-	if ((peerstate->to_save&DC_FORCE_REGOSSIP) || create) {
+	if ((peerstate->to_save&DC_SAVE_ALL) || create) {
 		dc_reset_gossiped_timestamp(peerstate->context, 0);
 	}
 
@@ -320,7 +320,7 @@ int dc_apeerstate_init_from_header(dc_apeerstate_t* peerstate, const dc_aheader_
 	peerstate->addr                = dc_strdup(header->addr);
 	peerstate->last_seen           = message_time;
 	peerstate->last_seen_autocrypt = message_time;
-	peerstate->to_save            |= DC_SAVE_ALL | DC_FORCE_REGOSSIP;
+	peerstate->to_save            |= DC_SAVE_ALL;
 	peerstate->prefer_encrypt      = header->prefer_encrypt;
 
 	peerstate->public_key = dc_key_new();
@@ -340,7 +340,7 @@ int dc_apeerstate_init_from_gossip(dc_apeerstate_t* peerstate, const dc_aheader_
 	dc_apeerstate_empty(peerstate);
 	peerstate->addr                = dc_strdup(gossip_header->addr);
 	peerstate->gossip_timestamp    = message_time;
-	peerstate->to_save            |= DC_SAVE_ALL | DC_FORCE_REGOSSIP;
+	peerstate->to_save            |= DC_SAVE_ALL;
 
 	peerstate->gossip_key = dc_key_new();
 	dc_key_set_from_key(peerstate->gossip_key, gossip_header->public_key);
@@ -402,7 +402,7 @@ void dc_apeerstate_apply_header(dc_apeerstate_t* peerstate, const dc_aheader_t* 
 		{
 			dc_key_set_from_key(peerstate->public_key, header->public_key);
 			dc_apeerstate_recalc_fingerprint(peerstate);
-			peerstate->to_save |= DC_SAVE_ALL | DC_FORCE_REGOSSIP;
+			peerstate->to_save |= DC_SAVE_ALL;
 		}
 	}
 }
@@ -430,7 +430,7 @@ void dc_apeerstate_apply_gossip(dc_apeerstate_t* peerstate, const dc_aheader_t* 
 		{
 			dc_key_set_from_key(peerstate->gossip_key, gossip_header->public_key);
 			dc_apeerstate_recalc_fingerprint(peerstate);
-			peerstate->to_save |= DC_SAVE_ALL | DC_FORCE_REGOSSIP;
+			peerstate->to_save |= DC_SAVE_ALL;
 		}
 	}
 }
@@ -468,7 +468,7 @@ int dc_apeerstate_recalc_fingerprint(dc_apeerstate_t* peerstate)
 		 || peerstate->public_key_fingerprint[0]==0
 		 || strcasecmp(old_public_fingerprint, peerstate->public_key_fingerprint)!=0)
 		{
-			peerstate->to_save  |= DC_SAVE_ALL | DC_FORCE_REGOSSIP;
+			peerstate->to_save  |= DC_SAVE_ALL;
 
 			if (old_public_fingerprint && old_public_fingerprint[0]) { // no degrade event when we recveive just the initial fingerprint
 				peerstate->degrade_event |= DC_DE_FINGERPRINT_CHANGED;
@@ -487,7 +487,7 @@ int dc_apeerstate_recalc_fingerprint(dc_apeerstate_t* peerstate)
 		 || peerstate->gossip_key_fingerprint[0]==0
 		 || strcasecmp(old_gossip_fingerprint, peerstate->gossip_key_fingerprint)!=0)
 		{
-			peerstate->to_save  |= DC_SAVE_ALL | DC_FORCE_REGOSSIP;
+			peerstate->to_save  |= DC_SAVE_ALL;
 
 			if (old_gossip_fingerprint && old_gossip_fingerprint[0]) { // no degrade event when we recveive just the initial fingerprint
 				peerstate->degrade_event |= DC_DE_FINGERPRINT_CHANGED;

--- a/src/dc_apeerstate.h
+++ b/src/dc_apeerstate.h
@@ -47,8 +47,7 @@ struct _dc_apeerstate
 	char*          verified_key_fingerprint;
 
 	#define        DC_SAVE_TIMESTAMPS 0x01
-	#define        DC_SAVE_ALL        0x02
-	#define        DC_FORCE_REGOSSIP  0x04
+	#define        DC_SAVE_ALL        0x02 // implies a call to dc_reset_gossiped_timestamp()
 	int            to_save;
 
 	#define        DC_DE_ENCRYPTION_PAUSED   0x01 // recoverable by an incoming encrypted mail

--- a/src/dc_apeerstate.h
+++ b/src/dc_apeerstate.h
@@ -48,6 +48,7 @@ struct _dc_apeerstate
 
 	#define        DC_SAVE_TIMESTAMPS 0x01
 	#define        DC_SAVE_ALL        0x02
+	#define        DC_FORCE_REGOSSIP  0x04
 	int            to_save;
 
 	#define        DC_DE_ENCRYPTION_PAUSED   0x01 // recoverable by an incoming encrypted mail

--- a/src/dc_chat.h
+++ b/src/dc_chat.h
@@ -24,6 +24,7 @@ struct _dc_chat
 	char*           grpid;            /**< Group ID that is used by all clients. Only used if the chat is a group. NULL if unset */
 	int             blocked;          /**< One of DC_CHAT_*_BLOCKED */
 	dc_param_t*     param;            /**< Additional parameters for a chat. Should not be used directly. */
+	time_t          gossiped_timestamp;
 };
 
 int             dc_chat_load_from_db               (dc_chat_t*, uint32_t id);
@@ -52,6 +53,9 @@ void            dc_set_group_explicitly_left               (dc_context_t*, const
 
 #define         DC_FROM_HANDSHAKE                          0x01
 int             dc_add_contact_to_chat_ex                  (dc_context_t*, uint32_t chat_id, uint32_t contact_id, int flags);
+
+void            dc_reset_gossiped_timestamp                (dc_context_t*, uint32_t chat_id);
+void            dc_set_gossiped_timestamp                  (dc_context_t*, uint32_t chat_id, time_t);
 
 
 #ifdef __cplusplus

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -153,7 +153,9 @@ struct _dc_e2ee_helper {
 
 };
 
-void            dc_e2ee_encrypt      (dc_context_t*, const clist* recipients_addr, int force_plaintext, int e2ee_guaranteed, int min_verified, struct mailmime* in_out_message, dc_e2ee_helper_t*);
+void            dc_e2ee_encrypt      (dc_context_t*, const clist* recipients_addr,
+                                      int force_plaintext, int e2ee_guaranteed, int min_verified,
+                                      int do_gossip, struct mailmime* in_out_message, dc_e2ee_helper_t*);
 void            dc_e2ee_decrypt      (dc_context_t*, struct mailmime* in_out_message, dc_e2ee_helper_t*); /* returns 1 if sth. was decrypted, 0 in other cases */
 void            dc_e2ee_thanks       (dc_e2ee_helper_t*); /* frees data referenced by "mailmime" but not freed by mailmime_free(). After calling this function, in_out_message cannot be used any longer! */
 int             dc_ensure_secret_key_exists (dc_context_t*); /* makes sure, the private key exists, needed only for exporting keys and the case no message was sent before */

--- a/src/dc_e2ee.c
+++ b/src/dc_e2ee.c
@@ -290,6 +290,7 @@ void dc_e2ee_encrypt(dc_context_t* context, const clist* recipients_addr,
                     int force_unencrypted,
                     int e2ee_guaranteed, /*set if e2ee was possible on sending time; we should not degrade to transport*/
                     int min_verified,
+                    int do_gossip,
                     struct mailmime* in_out_message, dc_e2ee_helper_t* helper)
 {
 	int                     col = 0;
@@ -383,12 +384,14 @@ void dc_e2ee_encrypt(dc_context_t* context, const clist* recipients_addr,
 			mailmime_get_content_message(), NULL, NULL, NULL, NULL, imffields_encrypted, part_to_encrypt);
 
 		/* gossip keys */
-		int iCnt = dc_array_get_cnt(peerstates);
-		if (iCnt > 1) {
-			for (int i = 0; i < iCnt; i++) {
-				char* p = dc_apeerstate_render_gossip_header((dc_apeerstate_t*)dc_array_get_ptr(peerstates, i), min_verified);
-				if (p) {
-					mailimf_fields_add(imffields_encrypted, mailimf_field_new_custom(strdup("Autocrypt-Gossip"), p/*takes ownership*/));
+		if (do_gossip) {
+			int iCnt = dc_array_get_cnt(peerstates);
+			if (iCnt > 1) {
+				for (int i = 0; i < iCnt; i++) {
+					char* p = dc_apeerstate_render_gossip_header((dc_apeerstate_t*)dc_array_get_ptr(peerstates, i), min_verified);
+					if (p) {
+						mailimf_fields_add(imffields_encrypted, mailimf_field_new_custom(strdup("Autocrypt-Gossip"), p/*takes ownership*/));
+					}
 				}
 			}
 		}

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -282,6 +282,10 @@ static void dc_job_do_DC_JOB_SEND_MSG_TO_SMTP(dc_context_t* context, dc_job_t* j
 	/* done */
 	dc_sqlite3_begin_transaction(context->sql);
 
+		if (mimefactory.out_gossiped) {
+			dc_set_gossiped_timestamp(context, mimefactory.msg->chat_id, time(NULL));
+		}
+
 		dc_update_msg_state(context, mimefactory.msg->id, DC_STATE_OUT_DELIVERED);
 		if (mimefactory.out_encrypted && dc_param_get_int(mimefactory.msg->param, DC_PARAM_GUARANTEE_E2EE, 0)==0) {
 			dc_param_set_int(mimefactory.msg->param, DC_PARAM_GUARANTEE_E2EE, 1); /* can upgrade to E2EE - fine! */

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -441,6 +441,7 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 	int                    e2ee_guaranteed = 0;
 	int                    min_verified = DC_NOT_VERIFIED;
 	int                    force_plaintext = 0; // 1=add Autocrypt-header (needed eg. for handshaking), 2=no Autocrypte-header (used for MDN)
+	int                    do_gossip = 1;
 	char*                  grpimage = NULL;
 	dc_e2ee_helper_t       e2ee_helper;
 	memset(&e2ee_helper, 0, sizeof(dc_e2ee_helper_t));
@@ -761,7 +762,9 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 	mailimf_fields_add(imf_fields, mailimf_field_new(MAILIMF_FIELD_SUBJECT, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, subject, NULL, NULL, NULL));
 
 	if (force_plaintext!=DC_FP_NO_AUTOCRYPT_HEADER) {
-		dc_e2ee_encrypt(factory->context, factory->recipients_addr, force_plaintext, e2ee_guaranteed, min_verified, message, &e2ee_helper);
+		dc_e2ee_encrypt(factory->context, factory->recipients_addr,
+			force_plaintext, e2ee_guaranteed, min_verified,
+			do_gossip, message, &e2ee_helper);
 	}
 
 	if (e2ee_helper.encryption_successfull) {

--- a/src/dc_mimefactory.h
+++ b/src/dc_mimefactory.h
@@ -52,6 +52,7 @@ struct _dc_mimefactory {
 	// out: after a call to dc_mimefactory_render(), here's the data or the error
 	MMAPString*   out;
 	int           out_encrypted;
+	int           out_gossiped;
 	char*         error;
 
 	/* private */

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -849,6 +849,8 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 			}
 		}
 		send_EVENT_CHAT_MODIFIED = 1;
+
+		dc_reset_gossiped_timestamp(context, chat_id);
 	}
 
 	if (send_EVENT_CHAT_MODIFIED) {

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -539,6 +539,16 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			}
 		#undef NEW_DB_VERSION
 
+		#define NEW_DB_VERSION 49
+			if (dbversion < NEW_DB_VERSION)
+			{
+				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN gossiped_timestamp INTEGER DEFAULT 0;");
+
+				dbversion = NEW_DB_VERSION;
+				dc_sqlite3_set_config_int(sql, "dbversion", NEW_DB_VERSION);
+			}
+		#undef NEW_DB_VERSION
+
 		// (2) updates that require high-level objects
 		// (the structure is complete now and all objects are usable)
 		// --------------------------------------------------------------------


### PR DESCRIPTION
the aim of this pr is to add the [Autocrypt-Gossip](https://autocrypt.org/level1.html#key-gossip) headers less often without limiting its functionality too much.

for this purpose, the following changes are done:

- each chat has a timestamp marking the time of the last outgoing gossiped keys (`gossiped_timestamp`)
- `gossiped_timestamp` defaults to `0`
- `gossiped_timestamp` is reset (set to  `0`) for a single chat whenever the memberlist of the chat changes (never for 1:1 chats)
- `gossiped_timestamp` is reset for all chats on any incoming key changes (if needed, this can be optimized to reset `gossiped_timestamp` only for chats that really use the changed keys)
- finally, outgoing keys are gossiped only when `gossiped_timestamp` for a chat is `0` or older than 48 hours.

this saves about 2.5k per recipient per message. so already in small groups with 3 members a single _encrypted_ text messages saves about 5k and is now about 6k in size. in _larger_ group, this obviously saves some 10k per message.

for unencrypted messages, this change has no effect as keys are not gossiped at all there.

tl;dr - keys are gossiped on changes on keys or memberlist and once every 48 hours.