### PR TITLE
email interactions

### DIFF
--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -1052,16 +1052,22 @@ dc_array_t* dc_get_chat_msgs(dc_context_t* context, uint32_t chat_id, uint32_t f
 
 	if (chat_id==DC_CHAT_ID_DEADDROP)
 	{
+		int show_emails = dc_sqlite3_get_config_int(context->sql,
+			"show_emails", DC_SHOW_EMAILS_DEFAULT);
+
 		stmt = dc_sqlite3_prepare(context->sql,
 			"SELECT m.id, m.timestamp"
 				" FROM msgs m"
 				" LEFT JOIN chats ON m.chat_id=chats.id"
 				" LEFT JOIN contacts ON m.from_id=contacts.id"
 				" WHERE m.from_id!=" DC_STRINGIFY(DC_CONTACT_ID_SELF)
+				"   AND m.from_id!=" DC_STRINGIFY(DC_CONTACT_ID_DEVICE)
 				"   AND m.hidden=0 "
 				"   AND chats.blocked=" DC_STRINGIFY(DC_CHAT_DEADDROP_BLOCKED)
 				"   AND contacts.blocked=0"
+				"   AND m.msgrmsg>=? "
 				" ORDER BY m.timestamp,m.id;"); /* the list starts with the oldest message*/
+		sqlite3_bind_int(stmt, 1, show_emails==DC_SHOW_EMAILS_ALL? 0 : 1);
 	}
 	else if (chat_id==DC_CHAT_ID_STARRED)
 	{

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -516,7 +516,7 @@ static char* get_sys_config_str(const char* key)
  *                    show direct replies to chats only (default),
  *                    DC_SHOW_EMAILS_ACCEPTED_CONTACTS (1)=
  *                    also show all mails of confirmed contacts,
- *                    DC_SHOW_EMAILS_ALL (3, not: 2)=
+ *                    DC_SHOW_EMAILS_ALL (2)=
  *                    also show mails of unconfirmed contacts in the deaddrop.
  * - `save_mime_headers` = 1=save mime headers
  *                    and make dc_get_mime_headers() work for subsequent calls,

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -36,6 +36,7 @@ static const char* config_keys[] = {
 	,"sentbox_watch"
 	,"mvbox_watch"
 	,"mvbox_move"
+	,"show_emails"
 	,"save_mime_headers"
 	,"configured_addr"
 	,"configured_mail_server"
@@ -511,7 +512,14 @@ static char* get_sys_config_str(const char* key)
  * - `mvbox_move`   = 1=heuristically detect chat-messages
  *                    and move them to the `DeltaChat`-folder,
  *                    0=do not move chat-messages
- * - `save_mime_headers` = 1=save mime headers and make dc_get_mime_headers() work for subsequent calls,
+ * - `show_emails`  = DC_SHOW_EMAILS_OFF (0)=
+ *                    show direct replies to chats only (default),
+ *                    DC_SHOW_EMAILS_ACCEPTED_CONTACTS (1)=
+ *                    also show all mails of confirmed contacts,
+ *                    DC_SHOW_EMAILS_ALL (3, not: 2)=
+ *                    also show mails of unconfirmed contacts in the deaddrop.
+ * - `save_mime_headers` = 1=save mime headers
+ *                    and make dc_get_mime_headers() work for subsequent calls,
  *                    0=do not save mime headers (default)
  *
  * If you want to retrieve a value, use dc_get_config().
@@ -640,6 +648,9 @@ char* dc_get_config(dc_context_t* context, const char* key)
 		}
 		else if (strcmp(key, "mvbox_move")==0) {
 			value = dc_mprintf("%i", DC_MVBOX_MOVE_DEFAULT);
+		}
+		else if (strcmp(key, "show_emails")==0) {
+			value = dc_mprintf("%i", DC_SHOW_EMAILS_DEFAULT);
 		}
 		else if (strcmp(key, "selfstatus")==0) {
 			value = dc_stock_str(context, DC_STR_STATUSLINE);

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -135,6 +135,7 @@ int             dc_is_mvbox          (dc_context_t*, const char* folder);
 #define DC_SENTBOX_WATCH_DEFAULT  1
 #define DC_MVBOX_WATCH_DEFAULT    1
 #define DC_MVBOX_MOVE_DEFAULT     1
+#define DC_SHOW_EMAILS_DEFAULT    DC_SHOW_EMAILS_OFF
 
 
 typedef struct _dc_e2ee_helper dc_e2ee_helper_t;

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -1268,15 +1268,13 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 					chat_id = DC_CHAT_ID_TRASH;
 				}
 
-				/* degrade state for unknown senders and non-delta messages
-				(the latter may be removed if we run into spam problems, currently this is fine)
-				(noticed messages do count as being unread; therefore, the deaddrop will not popup in the chatlist) */
+				/* if the chat_id is blocked,
+				for unknown senders and non-delta messages set the state to NOTICED
+				to not result in a contact request (this would require the state FRESH) */
 				if (chat_id_blocked && state==DC_STATE_IN_FRESH)
 				{
 					if (incoming_origin < DC_ORIGIN_MIN_VERIFIED
-					 && mime_parser->is_send_by_messenger == 0
-					 && !dc_is_mvbox(context, server_folder))
-					{
+					 && msgrmsg==0) {
 						state = DC_STATE_IN_NOTICED;
 					}
 				}
@@ -1299,7 +1297,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 
 					if (chat_id==0)
 					{
-						int create_blocked = (mime_parser->is_send_by_messenger && !dc_is_contact_blocked(context, to_id))? DC_CHAT_NOT_BLOCKED : DC_CHAT_DEADDROP_BLOCKED;
+						int create_blocked = (msgrmsg && !dc_is_contact_blocked(context, to_id))? DC_CHAT_NOT_BLOCKED : DC_CHAT_DEADDROP_BLOCKED;
 						dc_create_or_lookup_nchat_by_contact_id(context, to_id, create_blocked, &chat_id, &chat_id_blocked);
 						if (chat_id && chat_id_blocked && !create_blocked) {
 							dc_unblock_chat(context, chat_id);

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -476,7 +476,8 @@ cleanup:
  ******************************************************************************/
 
 
-static void create_or_lookup_adhoc_group(dc_context_t* context, dc_mimeparser_t* mime_parser, int create_blocked,
+static void create_or_lookup_adhoc_group(dc_context_t* context, dc_mimeparser_t* mime_parser,
+                                           int allow_creation, int create_blocked,
                                            int32_t from_id, const dc_array_t* to_ids,/*does not contain SELF*/
                                            uint32_t* ret_chat_id, int* ret_chat_id_blocked)
 {
@@ -521,6 +522,10 @@ static void create_or_lookup_adhoc_group(dc_context_t* context, dc_mimeparser_t*
 			chat_id_blocked = sqlite3_column_int(stmt, 1);
 			goto cleanup; /* success, chat found */
 		}
+	}
+
+	if (!allow_creation) {
+		goto cleanup;
 	}
 
 	/* we do not check if the message is a reply to another group, this may result in
@@ -674,7 +679,8 @@ which tries to create or find out the chat_id by:
 
 So when the function returns, the caller has the group id matching the current
 state of the group. */
-static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_parser, int create_blocked,
+static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_parser,
+                                     int allow_creation, int create_blocked,
                                      int32_t from_id, const dc_array_t* to_ids,
                                      uint32_t* ret_chat_id, int* ret_chat_id_blocked)
 {
@@ -734,7 +740,9 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 
 					if (grpid==NULL)
 					{
-						create_or_lookup_adhoc_group(context, mime_parser, create_blocked, from_id, to_ids, &chat_id, &chat_id_blocked);
+						create_or_lookup_adhoc_group(context, mime_parser,
+							allow_creation, create_blocked,
+							from_id, to_ids, &chat_id, &chat_id_blocked);
 						goto cleanup;
 					}
 				}
@@ -825,6 +833,10 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 			}
 		}
 
+		if (!allow_creation) {
+			goto cleanup;
+		}
+
 		chat_id = create_group_record(context, grpid, grpname, create_blocked, create_verified);
 		chat_id_blocked  = create_blocked;
 		chat_id_verified = create_verified;
@@ -838,7 +850,9 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 			chat_id = DC_CHAT_ID_TRASH; /* we got a message for a chat we've deleted - do not show this even as a normal chat */
 		}
 		else {
-			create_or_lookup_adhoc_group(context, mime_parser, create_blocked, from_id, to_ids, &chat_id, &chat_id_blocked);
+			create_or_lookup_adhoc_group(context, mime_parser,
+				allow_creation, create_blocked,
+				from_id, to_ids, &chat_id, &chat_id_blocked);
 		}
 		goto cleanup;
 	}
@@ -936,7 +950,8 @@ static void create_or_lookup_group(dc_context_t* context, dc_mimeparser_t* mime_
 		int is_contact_cnt = dc_get_chat_contact_cnt(context, chat_id);
 		if (is_contact_cnt > 3 /* to_ids_cnt==1 may be "From: A, To: B, SELF" as SELF is not counted in to_ids_cnt. So everything up to 3 is no error. */) {
 			chat_id = 0;
-			create_or_lookup_adhoc_group(context, mime_parser, create_blocked, from_id, to_ids, &chat_id, &chat_id_blocked);
+			create_or_lookup_adhoc_group(context, mime_parser,
+				allow_creation, create_blocked, from_id, to_ids, &chat_id, &chat_id_blocked);
 			goto cleanup;
 		}
 	}
@@ -975,6 +990,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 	int              chat_id_blocked = 0;
 	int              state = DC_STATE_UNDEFINED;
 	int              hidden = 0;
+	int              msgrmsg = 0;
 	int              add_delete_job = 0;
 	uint32_t         insert_msg_id = 0;
 
@@ -1142,6 +1158,11 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				}
 			}
 
+			msgrmsg = mime_parser->is_send_by_messenger; /* 1 or 0 for yes/no */
+			if (msgrmsg==0 && dc_is_reply_to_messenger_message(context, mime_parser)) {
+				msgrmsg = 2; /* 2=no, but is reply to messenger message */
+			}
+
 			/* check if the message introduces a new chat:
 			- outgoing messages introduce a chat with the first to: address if they are sent by a messenger
 			- incoming messages introduce a chat only for known contacts if they are sent by a messenger
@@ -1154,6 +1175,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				// handshake messages must be processed before chats are created (eg. contacs may be marked as verified)
 				assert( chat_id==0);
 				if (dc_mimeparser_lookup_field(mime_parser, "Secure-Join")) {
+					msgrmsg = 1; // avoid discarding by show_emails setting
 					dc_sqlite3_commit(context->sql);
 						int handshake = dc_handle_securejoin_handshake(context, mime_parser, from_id);
 						if (handshake & DC_HANDSHAKE_STOP_NORMAL_PROCESSING) {
@@ -1162,6 +1184,25 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 							state = DC_STATE_IN_SEEN;
 						}
 					dc_sqlite3_begin_transaction(context->sql);
+				}
+
+				/* incoming non-chat messages may be discarded;
+				maybe this can be optimized later,
+				by checking the state before the message body is downloaded */
+				int allow_creation = 1;
+				if (msgrmsg==0) {
+					/* this message is a classic email -
+					not a chat-message nor a reply to one */
+					int show_emails = dc_sqlite3_get_config_int(context->sql,
+						"show_emails", DC_SHOW_EMAILS_DEFAULT);
+
+					if (show_emails==DC_SHOW_EMAILS_OFF) {
+						chat_id = DC_CHAT_ID_TRASH;
+						allow_creation = 0;
+					}
+					else if (show_emails==DC_SHOW_EMAILS_ACCEPTED_CONTACTS) {
+						allow_creation = 0;
+					}
 				}
 
 				/* test if there is a normal chat with the sender - if so, this allows us to create groups in the next step */
@@ -1176,7 +1217,9 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 					/* try to create a group
 					(groups appear automatically only if the _sender_ is known, see core issue #54) */
 					int create_blocked = ((test_normal_chat_id&&test_normal_chat_id_blocked==DC_CHAT_NOT_BLOCKED) || incoming_origin>=DC_ORIGIN_MIN_START_NEW_NCHAT/*always false, for now*/)? DC_CHAT_NOT_BLOCKED : DC_CHAT_DEADDROP_BLOCKED;
-					create_or_lookup_group(context, mime_parser, create_blocked, from_id, to_ids, &chat_id, &chat_id_blocked);
+					create_or_lookup_group(context, mime_parser,
+						allow_creation, create_blocked,
+						from_id, to_ids, &chat_id, &chat_id_blocked);
 					if (chat_id && chat_id_blocked && !create_blocked) {
 						dc_unblock_chat(context, chat_id);
 						chat_id_blocked = 0;
@@ -1200,8 +1243,10 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 						chat_id         = test_normal_chat_id;
 						chat_id_blocked = test_normal_chat_id_blocked;
 					}
-					else {
-						dc_create_or_lookup_nchat_by_contact_id(context, from_id, create_blocked, &chat_id, &chat_id_blocked);
+					else if(allow_creation) {
+						dc_create_or_lookup_nchat_by_contact_id(context, from_id,
+							create_blocked,
+							&chat_id, &chat_id_blocked);
 					}
 
 					if (chat_id && chat_id_blocked) {
@@ -1245,7 +1290,7 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 
 					if (chat_id==0)
 					{
-						create_or_lookup_group(context, mime_parser, DC_CHAT_NOT_BLOCKED, from_id, to_ids, &chat_id, &chat_id_blocked);
+						create_or_lookup_group(context, mime_parser, 1, DC_CHAT_NOT_BLOCKED, from_id, to_ids, &chat_id, &chat_id_blocked);
 						if (chat_id && chat_id_blocked) {
 							dc_unblock_chat(context, chat_id);
 							chat_id_blocked = 0;
@@ -1317,11 +1362,6 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				if (fld_references) {
 					mime_references = dc_str_from_clist(field->fld_data.fld_references->mid_list, " ");
 				}
-			}
-
-			int msgrmsg = mime_parser->is_send_by_messenger; /* 1 or 0 for yes/no */
-			if (msgrmsg==0 && dc_is_reply_to_messenger_message(context, mime_parser)) {
-				msgrmsg = 2; /* 2=no, but is reply to messenger message */
 			}
 
 			/* fine, so far.  now, split the message into simple parts usable as "short messages"

--- a/src/dc_stock.c
+++ b/src/dc_stock.c
@@ -15,7 +15,7 @@ static char* default_string(int id)
 		case DC_STR_MEMBER:                return dc_strdup("%1$s member(s)");
 		case DC_STR_CONTACT:               return dc_strdup("%1$s contact(s)");
 		case DC_STR_VOICEMESSAGE:          return dc_strdup("Voice message");
-		case DC_STR_DEADDROP:              return dc_strdup("Mailbox");
+		case DC_STR_DEADDROP:              return dc_strdup("Contact requests");
 		case DC_STR_IMAGE:                 return dc_strdup("Image");
 		case DC_STR_GIF:                   return dc_strdup("GIF");
 		case DC_STR_VIDEO:                 return dc_strdup("Video");

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -1125,7 +1125,7 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  */
 #define DC_SHOW_EMAILS_OFF               0
 #define DC_SHOW_EMAILS_ACCEPTED_CONTACTS 1
-#define DC_SHOW_EMAILS_ALL               3
+#define DC_SHOW_EMAILS_ALL               2
 
 
 /*

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -1121,6 +1121,14 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 
 
 /*
+ * Values for dc_get|set_config("show_emails")
+ */
+#define DC_SHOW_EMAILS_OFF               0
+#define DC_SHOW_EMAILS_ACCEPTED_CONTACTS 1
+#define DC_SHOW_EMAILS_ALL               3
+
+
+/*
  * TODO: Strings need some doumentation about used placeholders.
  *
  * @defgroup DC_STR DC_STR


### PR DESCRIPTION
this pr will improve the interaction between chats and email and is the core-part of https://github.com/deltachat/deltachat-android/pull/742

todo:

- [X] add a config option
- [x] for show_emails<1, do not add emails to chats
- [x] make sure, the popping up contact-requests match the setting
- [x] make sure, cancelled contact request can be reinitiated by the contact list
- [x] outgoing messages must be not be displayed in delta when sent as non-chat to non-chat (unless the option says show_emails=accepted_contacts)
- [x] for existing installations, use default of DC_SHOW_EMAILS_ALL; for new ones, this will be DC_SHOW_EMAILS_NO

in the future, when things work out, we can refine the downloading of messages then - eg. maybe avoiding to download non-chat-mails at all.