### PR TITLE
probing STARTTLS on port 25

### DIFF
--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -1001,7 +1001,13 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 		{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 
 		if (!dc_smtp_connect(context->smtp, param)) {
-			goto cleanup;
+			PROGRESS(860)
+
+			param->send_port = TYPICAL_SMTP_PLAIN_PORT;
+			{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
+			if (!dc_smtp_connect(context->smtp, param)) {
+				goto cleanup;
+			}
 		}
 	}
 

--- a/src/dc_configure.c
+++ b/src/dc_configure.c
@@ -1003,7 +1003,9 @@ void dc_job_do_DC_JOB_CONFIGURE_IMAP(dc_context_t* context, dc_job_t* job)
 		if (!dc_smtp_connect(context->smtp, param)) {
 			PROGRESS(860)
 
-			param->send_port = TYPICAL_SMTP_PLAIN_PORT;
+			param->server_flags &= ~DC_LP_SMTP_SOCKET_FLAGS;
+			param->server_flags |=  DC_LP_SMTP_SOCKET_STARTTLS;
+			param->send_port    =   TYPICAL_SMTP_PLAIN_PORT;
 			{ char* r = dc_loginparam_get_readable(param); dc_log_info(context, 0, "Trying: %s", r); free(r); }
 			if (!dc_smtp_connect(context->smtp, param)) {
 				goto cleanup;


### PR DESCRIPTION
seems to be far away from standard but also is known to be used eg. in cuba.

as this probe is done if everything else is failing and does not force a PLAIN connection, however, i think it should not harm (famous last words (tm))