### PR TITLE
location streaming

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -914,6 +914,8 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				ret = dc_mprintf("%i contacts\nLocation streaming: %i",
 					(int)dc_array_get_cnt(contacts),
 					dc_is_sending_locations_to_chat(context, dc_chat_get_id(sel_chat)));
+
+				dc_array_unref(contacts);
 			}
 			else {
 				ret = COMMAND_FAILED;

--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -928,7 +928,9 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 			if (arg1 && arg1[0]) {
 				int seconds = atoi(arg1);
 				dc_send_locations_to_chat(context, dc_chat_get_id(sel_chat), seconds);
-				ret = COMMAND_SUCCEEDED;
+				ret = dc_mprintf("Locations will be sent to Chat#%i for %i seconds. "
+					"Use 'setlocation <lat> <lng>' to play around.",
+					dc_chat_get_id(sel_chat), seconds);
 			}
 			else {
 				ret = dc_strdup("ERROR: No timeout given.");
@@ -945,8 +947,8 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 			*arg2 = 0; arg2++;
 			double latitude = atof(arg1);
 			double longitude = atof(arg2);
-			dc_set_location(context, latitude, longitude, 0.0);
-			ret = COMMAND_SUCCEEDED;
+			int continue_streaming = dc_set_location(context, latitude, longitude, 0.0);
+			ret = dc_strdup(continue_streaming? "Success, streaming should be continued." : "Success, streaming can be stoppped.");
 		}
 		else {
 			ret = dc_strdup("ERROR: Latitude or longitude not given.");

--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -458,6 +458,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"chatinfo\n"
 				"sendlocations <seconds>\n"
 				"setlocation <lat> <lng>\n"
+				"dellocations\n"
 				"getlocations\n"
 				"send <text>\n"
 				"sendimage <file> [<text>]\n"
@@ -953,6 +954,10 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 		else {
 			ret = dc_strdup("ERROR: Latitude or longitude not given.");
 		}
+	}
+	else if (strcmp(cmd, "dellocations")==0) {
+		dc_delete_all_locations(context);
+		ret = COMMAND_SUCCEEDED;
 	}
 	else if (strcmp(cmd, "send")==0)
 	{

--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -302,13 +302,17 @@ static void log_msglist(dc_context_t* context, dc_array_t* msglist)
 }
 
 
-static void log_contactlist(dc_context_t* context, dc_array_t* contacts)
+static void log_contactlist(dc_context_t* context, dc_array_t* contacts,
+                            uint32_t add_locations_for_chat)
 {
-	int              i, cnt = dc_array_get_cnt(contacts);
 	dc_contact_t*    contact = NULL;
 	dc_apeerstate_t* peerstate = dc_apeerstate_new(context);
 
-	for (i = 0; i < cnt; i++) {
+	if (!dc_array_search_id(contacts, DC_CONTACT_ID_SELF, NULL)) {
+		dc_array_add_id(contacts, DC_CONTACT_ID_SELF);
+	}
+
+	for (int i = 0; i < dc_array_get_cnt(contacts); i++) {
 		uint32_t contact_id = dc_array_get_id(contacts, i);
 		char* line = NULL;
 		char* line2 = NULL;
@@ -333,13 +337,28 @@ static void log_contactlist(dc_context_t* context, dc_array_t* contacts)
 			dc_contact_unref(contact);
 			free(name);
 			free(addr);
+			dc_log_info(context, 0, "Contact#%i: %s%s", (int)contact_id, line, line2? line2:"");
+			free(line);
+			free(line2);
+
+			if (add_locations_for_chat) {
+				dc_array_t* loc = dc_get_locations(context, add_locations_for_chat, contact_id);
+				for (int j=0; j<dc_array_get_cnt(loc); j++) {
+					char* timestr = dc_timestamp_to_str(dc_array_get_timestamp(loc, j));
+					dc_log_info(context, 0, "%s: lat=%f lng=%f acc=%f msg_id=%i",
+						timestr,
+						dc_array_get_latitude(loc, j),
+						dc_array_get_longitude(loc, j),
+						dc_array_get_accuracy(loc, j),
+						dc_array_get_msg_id(loc, j));
+					free(timestr);
+				}
+				if (dc_array_get_cnt(loc)==0) {
+					dc_log_info(context, 0, "No locations.");
+				}
+				dc_array_unref(loc);
+			}
 		}
-		else {
-			line = dc_strdup("Read error.");
-		}
-		dc_log_info(context, 0, "Contact#%i: %s%s", (int)contact_id, line, line2? line2:"");
-		free(line);
-		free(line2);
 	}
 
 	dc_apeerstate_unref(peerstate);
@@ -439,6 +458,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"chatinfo\n"
 				"sendlocations <seconds>\n"
 				"setlocation <lat> <lng>\n"
+				"getlocations\n"
 				"send <text>\n"
 				"sendimage <file> [<text>]\n"
 				"sendfile <file>\n"
@@ -880,13 +900,16 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 			ret = dc_strdup("No chat selected.");
 		}
 	}
-	else if (strcmp(cmd, "chatinfo")==0)
+	else if (strcmp(cmd, "chatinfo")==0 || strcmp(cmd, "getlocations")==0)
 	{
 		if (sel_chat) {
 			dc_array_t* contacts = dc_get_chat_contacts(context, dc_chat_get_id(sel_chat));
 			if (contacts) {
 				dc_log_info(context, 0, "Memberlist:");
-				log_contactlist(context, contacts);
+
+				log_contactlist(context, contacts,
+					strcmp(cmd, "getlocations")==0? dc_chat_get_id(sel_chat) : 0);
+
 				ret = dc_mprintf("%i contacts\nLocation streaming: %i",
 					(int)dc_array_get_cnt(contacts),
 					dc_is_sending_locations_to_chat(context, dc_chat_get_id(sel_chat)));
@@ -1143,7 +1166,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 	{
 		dc_array_t* contacts = dc_get_contacts(context, strcmp(cmd, "listverified")==0? DC_GCL_VERIFIED_ONLY|DC_GCL_ADD_SELF : DC_GCL_ADD_SELF, arg1);
 		if (contacts) {
-			log_contactlist(context, contacts);
+			log_contactlist(context, contacts, 0);
 			ret = dc_mprintf("%i contacts.", (int)dc_array_get_cnt(contacts));
 			dc_array_unref(contacts);
 		}

--- a/cmdline/main.c
+++ b/cmdline/main.c
@@ -109,6 +109,10 @@ static uintptr_t receive_event(dc_context_t* context, int event, uintptr_t data1
 			printf(ANSI_YELLOW "{{Received DC_EVENT_CONTACTS_CHANGED()}}\n" ANSI_NORMAL);
 			break;
 
+		case DC_EVENT_LOCATION_CHANGED:
+			printf(ANSI_YELLOW "{{Received DC_EVENT_LOCATION_CHANGED(contact=%i)}}\n" ANSI_NORMAL, (int)data1);
+			break;
+
 		case DC_EVENT_CONFIGURE_PROGRESS:
 			printf(ANSI_YELLOW "{{Received DC_EVENT_CONFIGURE_PROGRESS(%i ‰)}}\n" ANSI_NORMAL, (int)data1);
 			break;

--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -192,6 +192,32 @@ void stress_functions(dc_context_t* context)
 		dc_simplify_unref(simplify);
 	}
 
+	{
+		const char* xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		                  "<kml xmlns=\"http://www.opengis.net/kml/2.2\">\n"
+		                  "<Document addr=\"user@example.org\">\n"
+		                  "<Placemark><Timestamp><when>2019-03-06T21:09:57Z</when></Timestamp><Point><coordinates accuracy=\"32.000000\">9.423110,53.790302</coordinates></Point></Placemark>\n"
+		                  "<PlaceMARK>\n<Timestamp><WHEN > \n\t2018-12-13T22:11:12Z\t</wHeN></Timestamp><Point><coordinates aCCuracy=\"2.500000\"> 19.423110 \t , \n 63.790302\n </coordinates></Point></Placemark>\n"
+		                  "</Document>\n"
+		                  "</kml>";
+		dc_kml_t* kml = dc_kml_parse(context, xml, strlen(xml));
+
+		assert( kml->addr && strcmp(kml->addr, "user@example.org")==0 );
+		assert( dc_array_get_cnt(kml->locations)==2 );
+
+		double lat = dc_array_get_latitude (kml->locations, 0); assert (lat>53.6 && lat<53.8);
+		double lng = dc_array_get_longitude(kml->locations, 0); assert (lng> 9.3 && lng< 9.5);
+		double acc = dc_array_get_accuracy (kml->locations, 0); assert (acc>31.9 && acc<32.1);
+		assert( dc_array_get_timestamp(kml->locations, 0)==1551906597 );
+
+		lat = dc_array_get_latitude (kml->locations, 1); assert (lat>63.6 && lat<63.8);
+		lng = dc_array_get_longitude(kml->locations, 1); assert (lng>19.3 && lng<19.5);
+		acc = dc_array_get_accuracy (kml->locations, 1); assert (acc> 2.4 && acc< 2.6);
+		assert( dc_array_get_timestamp(kml->locations, 1)==1544739072 );
+
+		dc_kml_unref(kml);
+	}
+
 	/* test file functions
 	 **************************************************************************/
 

--- a/src/dc_array.c
+++ b/src/dc_array.c
@@ -9,14 +9,15 @@
  *
  * @private @memberof dc_array_t
  * @param context The context object that should be stored in the array object. May be NULL.
+ * @param type 0 for a standard array of int or one of DC_ARRAY_*.
  * @param initsize Initial maximal size of the array. If you add more items, the internal data pointer is reallocated.
  * @return New array object of the requested size, the data should be set directly.
  */
-dc_array_t* dc_array_new(dc_context_t* context, size_t initsize)
+dc_array_t* dc_array_new_typed(dc_context_t* context, int type, size_t initsize)
 {
 	dc_array_t* array = NULL;
 
-	array = (dc_array_t*) malloc(sizeof(dc_array_t));
+	array = (dc_array_t*) calloc(1, sizeof(dc_array_t));
 	if (array==NULL) {
 		exit(47);
 	}
@@ -25,12 +26,19 @@ dc_array_t* dc_array_new(dc_context_t* context, size_t initsize)
 	array->context   = context;
 	array->count     = 0;
 	array->allocated = initsize<1? 1 : initsize;
+	array->type      = type;
 	array->array     = malloc(array->allocated * sizeof(uintptr_t));
 	if (array->array==NULL) {
 		exit(48);
 	}
 
 	return array;
+}
+
+
+dc_array_t* dc_array_new(dc_context_t* context, size_t initsize)
+{
+	return dc_array_new_typed(context, 0, initsize);
 }
 
 
@@ -47,6 +55,10 @@ void dc_array_unref(dc_array_t* array)
 {
 	if (array==NULL || array->magic!=DC_ARRAY_MAGIC) {
 		return;
+	}
+
+	if (array->type==DC_ARRAY_LOCATIONS) {
+		dc_array_free_ptr(array);
 	}
 
 	free(array->array);
@@ -292,6 +304,107 @@ void* dc_array_get_ptr(const dc_array_t* array, size_t index)
 	}
 
 	return (void*)array->array[index];
+}
+
+
+/**
+ * Return the latitude of the item at the given index.
+ *
+ * @memberof dc_array_t
+ * @param array The array object.
+ * @param index Index of the item. Must be between 0 and dc_array_get_cnt()-1.
+ * @return Latitude of the item at the given index.
+ *     0.0 if there is no latitude bound to the given item,
+ */
+double dc_array_get_latitude(const dc_array_t* array, size_t index)
+{
+	if (array==NULL || array->magic!=DC_ARRAY_MAGIC || index>=array->count
+	 || array->type!=DC_ARRAY_LOCATIONS || array->array[index]==0 ) {
+		return 0;
+	}
+
+	return ((struct _dc_location*)array->array[index])->latitude;
+}
+
+
+/**
+ * Return the longitude of the item at the given index.
+ *
+ * @memberof dc_array_t
+ * @param array The array object.
+ * @param index Index of the item. Must be between 0 and dc_array_get_cnt()-1.
+ * @return Latitude of the item at the given index.
+ *     0.0 if there is no longitude bound to the given item,
+ */
+double dc_array_get_longitude(const dc_array_t* array, size_t index)
+{
+	if (array==NULL || array->magic!=DC_ARRAY_MAGIC || index>=array->count
+	 || array->type!=DC_ARRAY_LOCATIONS || array->array[index]==0 ) {
+		return 0;
+	}
+
+	return ((struct _dc_location*)array->array[index])->longitude;
+}
+
+
+/**
+ * Return the accuracy of the item at the given index.
+ * See dc_set_location() for more information about the accuracy.
+ *
+ * @memberof dc_array_t
+ * @param array The array object.
+ * @param index Index of the item. Must be between 0 and dc_array_get_cnt()-1.
+ * @return Accuracy of the item at the given index.
+ *     0.0 if there is no longitude bound to the given item,
+ */
+double dc_array_get_accuracy(const dc_array_t* array, size_t index)
+{
+	if (array==NULL || array->magic!=DC_ARRAY_MAGIC || index>=array->count
+	 || array->type!=DC_ARRAY_LOCATIONS || array->array[index]==0 ) {
+		return 0;
+	}
+
+	return ((struct _dc_location*)array->array[index])->accuracy;
+}
+
+
+/**
+ * Return the timestamp of the item at the given index.
+ *
+ * @memberof dc_array_t
+ * @param array The array object.
+ * @param index Index of the item. Must be between 0 and dc_array_get_cnt()-1.
+ * @return Timestamp of the item at the given index.
+ *     0 if there is no timestamp bound to the given item,
+ */
+time_t dc_array_get_timestamp(const dc_array_t* array, size_t index)
+{
+	if (array==NULL || array->magic!=DC_ARRAY_MAGIC || index>=array->count
+	 || array->type!=DC_ARRAY_LOCATIONS || array->array[index]==0 ) {
+		return 0;
+	}
+
+	return ((struct _dc_location*)array->array[index])->timestamp;
+}
+
+
+/**
+ * Return the message-id of the item at the given index.
+ *
+ * @memberof dc_array_t
+ * @param array The array object.
+ * @param index Index of the item. Must be between 0 and dc_array_get_cnt()-1.
+ * @return Message-id of the item at the given index.
+ *     0 if there is no message-id bound to the given item,
+ */
+uint32_t dc_array_get_msg_id(const dc_array_t* array, size_t index)
+{
+	if (array==NULL || array->magic!=DC_ARRAY_MAGIC || index>=array->count
+	 || array->type!=DC_ARRAY_LOCATIONS || array->array[index]==0 ) {
+		return 0;
+	}
+
+	return ((struct _dc_location*)array->array[index])->msg_id;
 }
 
 

--- a/src/dc_array.h
+++ b/src/dc_array.h
@@ -19,16 +19,6 @@ struct _dc_array
 };
 
 
-struct _dc_location
-{
-	#define DC_ARRAY_LOCATIONS  1
-	double   latitude;
-	double   longitude;
-	double   accuracy;
-	time_t   timestamp;
-	uint32_t msg_id;
-};
-
 dc_array_t*      dc_array_new                 (dc_context_t*, size_t initsize);
 dc_array_t*      dc_array_new_typed           (dc_context_t*, int type, size_t initsize);
 void             dc_array_empty               (dc_array_t*);

--- a/src/dc_array.h
+++ b/src/dc_array.h
@@ -14,10 +14,24 @@ struct _dc_array
 	dc_context_t*   context;     /**< The context the array belongs to. May be NULL when NULL is given to dc_array_new(). */
 	size_t          allocated;   /**< The number of allocated items. Initially ~ 200. */
 	size_t          count;       /**< The number of used items. Initially 0. */
+	int             type;
 	uintptr_t*      array;       /**< The data items, can be used between data[0] and data[cnt-1]. Never NULL. */
 };
 
 
+struct _dc_location
+{
+	#define DC_ARRAY_LOCATIONS  1
+	double   latitude;
+	double   longitude;
+	double   accuracy;
+	time_t   timestamp;
+	uint32_t msg_id;
+};
+
+dc_array_t*      dc_array_new                 (dc_context_t*, size_t initsize);
+dc_array_t*      dc_array_new_typed           (dc_context_t*, int type, size_t initsize);
+void             dc_array_empty               (dc_array_t*);
 void             dc_array_free_ptr            (dc_array_t*);
 dc_array_t*      dc_array_duplicate           (const dc_array_t*);
 void             dc_array_sort_ids            (dc_array_t*);

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -142,6 +142,7 @@ typedef struct _dc_kml
 } dc_kml_t;
 
 char*           dc_get_location_kml  (dc_context_t*, uint32_t chat_id);
+int             dc_save_locations    (dc_context_t*, uint32_t chat_id, uint32_t contact_id, const dc_array_t*);
 dc_kml_t*       dc_kml_parse         (dc_context_t*, const char* content, size_t content_bytes);
 void            dc_kml_unref         (dc_kml_t*);
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -147,6 +147,8 @@ int             dc_save_locations         (dc_context_t*, uint32_t chat_id, uint
 dc_kml_t*       dc_kml_parse              (dc_context_t*, const char* content, size_t content_bytes);
 void            dc_kml_unref              (dc_kml_t*);
 
+void            dc_job_do_DC_JOB_MAYBE_SEND_LOCATIONS (dc_context_t*, dc_job_t*);
+
 
 // backups
 #define         DC_BAK_PREFIX                "delta-chat"

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -121,6 +121,8 @@ int             dc_is_inbox          (dc_context_t*, const char* folder);
 int             dc_is_sentbox        (dc_context_t*, const char* folder);
 int             dc_is_mvbox          (dc_context_t*, const char* folder);
 
+char*           dc_get_location_str  (dc_context_t*);
+
 #define         DC_BAK_PREFIX                "delta-chat"
 #define         DC_BAK_SUFFIX                "bak"
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -142,7 +142,7 @@ typedef struct _dc_kml
 } dc_kml_t;
 
 char*           dc_get_location_kml  (dc_context_t*, uint32_t chat_id);
-dc_kml_t*       dc_kml_parse         (dc_context_t*, const char* file_content);
+dc_kml_t*       dc_kml_parse         (dc_context_t*, const char* content, size_t content_bytes);
 void            dc_kml_unref         (dc_kml_t*);
 
 

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -141,10 +141,11 @@ typedef struct _dc_kml
 	dc_location_t curr;
 } dc_kml_t;
 
-char*           dc_get_location_kml  (dc_context_t*, uint32_t chat_id);
-int             dc_save_locations    (dc_context_t*, uint32_t chat_id, uint32_t contact_id, const dc_array_t*);
-dc_kml_t*       dc_kml_parse         (dc_context_t*, const char* content, size_t content_bytes);
-void            dc_kml_unref         (dc_kml_t*);
+char*           dc_get_location_kml       (dc_context_t*, uint32_t chat_id);
+void            dc_set_kml_sent_timestamp (dc_context_t*, uint32_t chat_id, time_t);
+int             dc_save_locations         (dc_context_t*, uint32_t chat_id, uint32_t contact_id, const dc_array_t*);
+dc_kml_t*       dc_kml_parse              (dc_context_t*, const char* content, size_t content_bytes);
+void            dc_kml_unref              (dc_kml_t*);
 
 
 // backups

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -121,7 +121,7 @@ int             dc_is_inbox          (dc_context_t*, const char* folder);
 int             dc_is_sentbox        (dc_context_t*, const char* folder);
 int             dc_is_mvbox          (dc_context_t*, const char* folder);
 
-char*           dc_get_location_str  (dc_context_t*);
+char*           dc_get_location_kml  (dc_context_t*, uint32_t chat_id);
 
 #define         DC_BAK_PREFIX                "delta-chat"
 #define         DC_BAK_SUFFIX                "bak"

--- a/src/dc_context.h
+++ b/src/dc_context.h
@@ -121,8 +121,32 @@ int             dc_is_inbox          (dc_context_t*, const char* folder);
 int             dc_is_sentbox        (dc_context_t*, const char* folder);
 int             dc_is_mvbox          (dc_context_t*, const char* folder);
 
-char*           dc_get_location_kml  (dc_context_t*, uint32_t chat_id);
 
+// location handling
+typedef struct _dc_location
+{
+	#define DC_ARRAY_LOCATIONS  1
+	double   latitude;
+	double   longitude;
+	double   accuracy;
+	time_t   timestamp;
+	uint32_t msg_id;
+} dc_location_t;
+
+typedef struct _dc_kml
+{
+	char*         addr;
+	dc_array_t*   locations;
+	int           tag;
+	dc_location_t curr;
+} dc_kml_t;
+
+char*           dc_get_location_kml  (dc_context_t*, uint32_t chat_id);
+dc_kml_t*       dc_kml_parse         (dc_context_t*, const char* file_content);
+void            dc_kml_unref         (dc_kml_t*);
+
+
+// backups
 #define         DC_BAK_PREFIX                "delta-chat"
 #define         DC_BAK_SUFFIX                "bak"
 

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -310,6 +310,10 @@ int dc_job_send_msg(dc_context_t* context, uint32_t msg_id)
 			dc_set_gossiped_timestamp(context, mimefactory.msg->chat_id, time(NULL));
 		}
 
+		if (mimefactory.out_locations_added) {
+			dc_set_kml_sent_timestamp(context, mimefactory.msg->chat_id, time(NULL));
+		}
+
 		if (mimefactory.out_encrypted && dc_param_get_int(mimefactory.msg->param, DC_PARAM_GUARANTEE_E2EE, 0)==0) {
 			dc_param_set_int(mimefactory.msg->param, DC_PARAM_GUARANTEE_E2EE, 1); /* can upgrade to E2EE - fine! */
 			dc_msg_save_param_to_disk(mimefactory.msg);

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -522,6 +522,22 @@ static time_t get_next_wakeup_time(dc_context_t* context, int thread)
 }
 
 
+int dc_job_action_exists(dc_context_t* context, int action)
+{
+	int           job_exists = 0;
+	sqlite3_stmt* stmt = NULL;
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"SELECT id FROM jobs WHERE action=?;");
+	sqlite3_bind_int  (stmt, 1, action);
+
+	job_exists = (sqlite3_step(stmt)==SQLITE_ROW);
+
+	sqlite3_finalize(stmt);
+	return job_exists;
+}
+
+
 void dc_job_add(dc_context_t* context, int action, int foreign_id, const char* param, int delay_seconds)
 {
 	time_t        timestamp = time(NULL);
@@ -684,6 +700,7 @@ static void dc_job_perform(dc_context_t* context, int thread, int probe_network)
 				case DC_JOB_SEND_MDN:             dc_job_do_DC_JOB_SEND                 (context, &job); break;
 				case DC_JOB_CONFIGURE_IMAP:       dc_job_do_DC_JOB_CONFIGURE_IMAP       (context, &job); break;
 				case DC_JOB_IMEX_IMAP:            dc_job_do_DC_JOB_IMEX_IMAP            (context, &job); break;
+				case DC_JOB_MAYBE_SEND_LOCATIONS: dc_job_do_DC_JOB_MAYBE_SEND_LOCATIONS (context, &job); break;
 				case DC_JOB_HOUSEKEEPING:         dc_housekeeping                       (context);       break;
 			}
 

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -10,7 +10,7 @@ extern "C" {
 #define DC_SMTP_THREAD            5000
 
 
-// jobs in the INBOX-thread
+// jobs in the INBOX-thread, range from DC_IMAP_THREAD..DC_IMAP_THREAD+999
 #define DC_JOB_HOUSEKEEPING           105    // low priority ...
 #define DC_JOB_DELETE_MSG_ON_IMAP     110
 #define DC_JOB_MARKSEEN_MDN_ON_IMAP   120
@@ -20,8 +20,9 @@ extern "C" {
 #define DC_JOB_IMEX_IMAP              910    // ... high priority
 
 
-// jobs in the SMTP-thread
-#define DC_JOB_SEND_MDN_OLD          5010    // low priority ...
+// jobs in the SMTP-thread, range from DC_SMTP_THREAD..DC_SMTP_THREAD+999
+#define DC_JOB_MAYBE_SEND_LOCATIONS  5005    // low priority ...
+#define DC_JOB_SEND_MDN_OLD          5010
 #define DC_JOB_SEND_MDN              5011
 #define DC_JOB_SEND_MSG_TO_SMTP_OLD  5900
 #define DC_JOB_SEND_MSG_TO_SMTP      5901    // ... high priority
@@ -57,6 +58,7 @@ struct _dc_job
 
 
 void     dc_job_add                   (dc_context_t*, int action, int foreign_id, const char* param, int delay);
+int      dc_job_action_exists         (dc_context_t*, int action);
 void     dc_job_kill_action           (dc_context_t*, int action); /* delete all pending jobs with the given action */
 
 int      dc_job_send_msg              (dc_context_t*, uint32_t msg_id); /* special case for DC_JOB_SEND_MSG_TO_SMTP */

--- a/src/dc_location.c
+++ b/src/dc_location.c
@@ -117,6 +117,21 @@ cleanup:
 }
 
 
+void dc_set_kml_sent_timestamp(dc_context_t* context,
+                               uint32_t chat_id, time_t timestamp)
+{
+	sqlite3_stmt* stmt = NULL;
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"UPDATE chats SET locations_last_sent=? WHERE id=?;");
+	sqlite3_bind_int64(stmt, 1, timestamp);
+	sqlite3_bind_int  (stmt, 2, chat_id);
+
+	sqlite3_step(stmt);
+	sqlite3_finalize(stmt);
+}
+
+
 /*******************************************************************************
  * parse kml-files
  ******************************************************************************/

--- a/src/dc_location.c
+++ b/src/dc_location.c
@@ -1,0 +1,163 @@
+#include "dc_context.h"
+#include "dc_mimeparser.h"
+#include "dc_job.h"
+
+
+/**
+ * Enable or disable location streaming for a chat.
+ * Locations are sent to all members of the chat for the given number of seconds;
+ * after that, location streaming is automatically disabled for the chat.
+ * The current location streaming state of a chat
+ * can be checked using dc_is_sending_locations_to_chat().
+ *
+ * The locations that should be sent to the chat can be set using
+ * dc_set_location().
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param chat_id Chat id to enable location streaming for.
+ * @param seconds >0: enable location streaming for the given number of seconds;
+ *     0: disable location streaming.
+ * @return None.
+ */
+void dc_send_locations_to_chat(dc_context_t* context, uint32_t chat_id,
+                               int seconds)
+{
+	sqlite3_stmt* stmt = NULL;
+
+	if (context==0 || context->magic!=DC_CONTEXT_MAGIC || seconds<0) {
+		goto cleanup;
+	}
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"UPDATE chats "
+		" SET locations_send_until=? "
+		" WHERE id=?");
+	sqlite3_bind_int64(stmt, 1, time(NULL)+seconds);
+	sqlite3_bind_int  (stmt, 2, chat_id);
+	sqlite3_step(stmt);
+
+	// TODO: send a status message
+
+cleanup:
+	sqlite3_finalize(stmt);
+}
+
+
+/**
+ * Check if location streaming is enabled for a chat.
+ * Location stream can be enabled or disabled using dc_send_locations_to_chat().
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param chat_id Chat id to check.
+ * @return 1: location streaming is enabled for the given chat;
+ *     0: location streaming is disabled for the given chat.
+ */
+int dc_is_sending_locations_to_chat(dc_context_t* context, uint32_t chat_id)
+{
+	int           is_sending_locations = 0;
+	sqlite3_stmt* stmt = NULL;
+	time_t        send_until = 0;
+
+	if (context==0 || context->magic!=DC_CONTEXT_MAGIC) {
+		goto cleanup;
+	}
+
+	stmt = dc_sqlite3_prepare(context->sql,
+		"SELECT locations_send_until "
+		" FROM chats "
+		" WHERE id=?");
+	sqlite3_bind_int(stmt, 1, chat_id);
+	if (sqlite3_step(stmt)!=SQLITE_ROW) {
+		goto cleanup;
+	}
+
+	send_until = sqlite3_column_int64(stmt, 0);
+
+	if (time(NULL) < send_until) {
+		is_sending_locations = 1;
+	}
+
+cleanup:
+	sqlite3_finalize(stmt);
+	return is_sending_locations;
+}
+
+
+/**
+ * Set current location.
+ * The location is sent to all chats where location streaming is enabled
+ * using dc_send_locations_to_chat().
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param latitude North-south position of the location.
+ *     Set to 0.0 if the latitude is not known.
+ * @param longitude East-west position of the location.
+ *     Set to 0.0 if the longitude is not known.
+ * @param accuracy Estimated accuracy of the location, radial, in meters.
+ *     Set to 0.0 if the accuracy is not known.
+ * @return 1: location streaming is still enabled for at least one chat,
+ *     this dc_set_location() should be called as soon as the location changes;
+ *     0: location streaming is no longer needed,
+ *     dc_is_sending_locations_to_chat() is false for all chats.
+ */
+int dc_set_location(dc_context_t* context,
+                    double latitude, double longitude, double accuracy)
+{
+	sqlite3_stmt* stmt = NULL;
+
+	if (context==0 || context->magic!=DC_CONTEXT_MAGIC
+	 || (latitude==0.0 && longitude==0.0)) {
+		goto cleanup;
+	}
+
+	stmt = dc_sqlite3_prepare(context->sql,
+			"INSERT INTO locations "
+			" (latitude, longitude, accuracy, timestamp, from_id)"
+			" VALUES (?,?,?,?,?);");
+	sqlite3_bind_double(stmt, 1, latitude);
+	sqlite3_bind_double(stmt, 2, longitude);
+	sqlite3_bind_double(stmt, 3, accuracy);
+	sqlite3_bind_int64 (stmt, 4, time(NULL));
+	sqlite3_bind_int   (stmt, 5, DC_CONTACT_ID_SELF);
+	sqlite3_step(stmt);
+
+	context->cb(context, DC_EVENT_LOCATION_CHANGED, DC_CONTACT_ID_SELF, 0);
+
+cleanup:
+	sqlite3_finalize(stmt);
+	return 1; // TODO: check state
+}
+
+
+
+char* dc_get_location_str(dc_context_t* context)
+{
+	sqlite3_stmt* stmt = NULL;
+	double        latitude = 0.0;
+	double        longitude = 0.0;
+	double        accuracy = 0.0;
+
+	if (context==0 || context->magic!=DC_CONTEXT_MAGIC) {
+		goto cleanup;
+	}
+
+	stmt = dc_sqlite3_prepare(context->sql,
+			"SELECT latitude, longitude, accuracy, timestamp "
+			" FROM locations "
+			" WHERE from_id=? "
+			"   AND timestamp=(SELECT MAX(timestamp) FROM locations WHERE from_id=?) ");
+	sqlite3_bind_int   (stmt, 1, DC_CONTACT_ID_SELF);
+	sqlite3_bind_int   (stmt, 2, DC_CONTACT_ID_SELF);
+	if (sqlite3_step(stmt)==SQLITE_ROW) {
+		latitude  = sqlite3_column_double(stmt, 0);
+		longitude = sqlite3_column_double(stmt, 1);
+		accuracy  = sqlite3_column_double(stmt, 2);
+	}
+
+cleanup:
+	sqlite3_finalize(stmt);
+    return dc_mprintf("%f %f %f", latitude, longitude, accuracy);
+}

--- a/src/dc_location.c
+++ b/src/dc_location.c
@@ -20,6 +20,7 @@ static char* get_kml_timestamp(time_t utc)
 
 char* dc_get_location_kml(dc_context_t* context, uint32_t chat_id)
 {
+	int              success = 0;
 	sqlite3_stmt*    stmt = NULL;
 	double           latitude = 0.0;
 	double           longitude = 0.0;
@@ -73,10 +74,15 @@ char* dc_get_location_kml(dc_context_t* context, uint32_t chat_id)
 		"</Document>\n"
 		"</kml>");
 
+	success = 1;
+
 cleanup:
 	sqlite3_finalize(stmt);
 	free(self_addr);
-	return ret.buf;
+	if (!success) {
+		free(ret.buf);
+	}
+	return success? ret.buf : NULL;
 }
 
 

--- a/src/dc_location.c
+++ b/src/dc_location.c
@@ -63,8 +63,8 @@ char* dc_get_location_kml(dc_context_t* context, uint32_t chat_id)
 			"</Placemark>\n",
 			timestamp,
 			accuracy,
-			latitude,
-			longitude);
+			longitude, // reverse order!
+			latitude);
 
 		free(timestamp);
 		timestamp = NULL;
@@ -170,13 +170,13 @@ static void kml_text_cb(void* userdata, const char* text, int len)
 		else if (kml->tag&TAG_COORDINATES) {
 			char* comma = strchr(val, ',');
 			if (comma) {
-				char* lat = val;
-				char* lng = comma+1;
+				char* longitude = val; // reverse order!
+				char* latitude = comma+1;
 				*comma = 0;
-				comma = strchr(lng, ',');
+				comma = strchr(latitude, ',');
 				if (comma) { *comma = 0; }
-				kml->curr.latitude = atof(lat);
-				kml->curr.longitude = atof(lng);
+				kml->curr.latitude = atof(latitude);
+				kml->curr.longitude = atof(longitude);
 			}
 		}
 

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -612,6 +612,12 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 			}
 		}
 
+		if (dc_is_sending_locations_to_chat(msg->context, msg->chat_id)) {
+			mailimf_fields_add(imf_fields, mailimf_field_new_custom(
+				strdup("Chat-Location"),
+				dc_get_location_str(msg->context)));
+		}
+
 		if (grpimage)
 		{
 			dc_msg_t* meta = dc_msg_new_untyped(factory->context);

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -612,12 +612,6 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 			}
 		}
 
-		if (dc_is_sending_locations_to_chat(msg->context, msg->chat_id)) {
-			mailimf_fields_add(imf_fields, mailimf_field_new_custom(
-				strdup("Chat-Location"),
-				dc_get_location_str(msg->context)));
-		}
-
 		if (grpimage)
 		{
 			dc_msg_t* meta = dc_msg_new_untyped(factory->context);
@@ -697,6 +691,19 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 
 		if (meta_part) {
 			mailmime_smart_add_part(message, meta_part); /* meta parts are only added if there are other parts */
+			parts++;
+		}
+
+		if (dc_is_sending_locations_to_chat(msg->context, msg->chat_id)) {
+			char* kml_file = dc_get_location_kml(msg->context, msg->chat_id);
+
+			struct mailmime_content* content_type = mailmime_content_new_with_str("application/vnd.google-earth.kml+xml");
+			struct mailmime_fields* mime_fields = mailmime_fields_new_filename(MAILMIME_DISPOSITION_TYPE_ATTACHMENT,
+				dc_strdup("location.kml"), MAILMIME_MECHANISM_8BIT);
+			struct mailmime* kml_mime_part = mailmime_new_empty(content_type, mime_fields);
+			mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
+
+			mailmime_smart_add_part(message, kml_mime_part);
 			parts++;
 		}
 	}

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -577,6 +577,13 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 			}
 		}
 
+		if (command==DC_CMD_LOCATION_STREAMING_SECONDS) {
+			int seconds = dc_param_get_int(msg->param, DC_PARAM_CMD_ARG, 0);
+			mailimf_fields_add(imf_fields, mailimf_field_new_custom(
+				strdup("Chat-Content"),
+				dc_mprintf("position-state; seconds=%i", seconds)));
+		}
+
 		if (command==DC_CMD_AUTOCRYPT_SETUP_MESSAGE) {
 			mailimf_fields_add(imf_fields, mailimf_field_new_custom(strdup("Autocrypt-Setup-Message"), strdup("v1")));
 			placeholdertext = dc_stock_str(factory->context, DC_STR_AC_SETUP_MSG_BODY);

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -696,15 +696,16 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 
 		if (dc_is_sending_locations_to_chat(msg->context, msg->chat_id)) {
 			char* kml_file = dc_get_location_kml(msg->context, msg->chat_id);
+			if (kml_file) {
+				struct mailmime_content* content_type = mailmime_content_new_with_str("application/vnd.google-earth.kml+xml");
+				struct mailmime_fields* mime_fields = mailmime_fields_new_filename(MAILMIME_DISPOSITION_TYPE_ATTACHMENT,
+					dc_strdup("location.kml"), MAILMIME_MECHANISM_8BIT);
+				struct mailmime* kml_mime_part = mailmime_new_empty(content_type, mime_fields);
+				mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
 
-			struct mailmime_content* content_type = mailmime_content_new_with_str("application/vnd.google-earth.kml+xml");
-			struct mailmime_fields* mime_fields = mailmime_fields_new_filename(MAILMIME_DISPOSITION_TYPE_ATTACHMENT,
-				dc_strdup("location.kml"), MAILMIME_MECHANISM_8BIT);
-			struct mailmime* kml_mime_part = mailmime_new_empty(content_type, mime_fields);
-			mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
-
-			mailmime_smart_add_part(message, kml_mime_part);
-			parts++;
+				mailmime_smart_add_part(message, kml_mime_part);
+				parts++;
+			}
 		}
 	}
 	else if (factory->loaded==DC_MF_MDN_LOADED)

--- a/src/dc_mimefactory.c
+++ b/src/dc_mimefactory.c
@@ -705,6 +705,7 @@ int dc_mimefactory_render(dc_mimefactory_t* factory)
 
 				mailmime_smart_add_part(message, kml_mime_part);
 				parts++;
+				factory->out_locations_added = 1;
 			}
 		}
 	}

--- a/src/dc_mimefactory.h
+++ b/src/dc_mimefactory.h
@@ -53,6 +53,7 @@ struct _dc_mimefactory {
 	MMAPString*   out;
 	int           out_encrypted;
 	int           out_gossiped;
+	int           out_locations_added;
 	char*         error;
 
 	/* private */

--- a/src/dc_mimefactory.h
+++ b/src/dc_mimefactory.h
@@ -14,6 +14,7 @@ typedef struct _dc_mimefactory dc_mimefactory_t;
 #define DC_CMD_MEMBER_REMOVED_FROM_GROUP   5
 #define DC_CMD_AUTOCRYPT_SETUP_MESSAGE     6
 #define DC_CMD_SECUREJOIN_MESSAGE          7
+#define DC_CMD_LOCATION_STREAMING_SECONDS  8
 
 
 typedef enum {

--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -940,6 +940,9 @@ void dc_mimeparser_empty(dc_mimeparser_t* mimeparser)
 	mimeparser->decrypting_failed = 0;
 
 	dc_e2ee_thanks(mimeparser->e2ee_helper);
+
+	dc_kml_unref(mimeparser->kml);
+	mimeparser->kml = NULL;
 }
 
 
@@ -1189,6 +1192,13 @@ static int dc_mimeparser_add_single_part_if_known(dc_mimeparser_t* mimeparser, s
 					else {
 						goto cleanup;
 					}
+				}
+
+				if (strncmp(desired_filename, "location", 8)==0
+				 && strncmp(desired_filename+strlen(desired_filename)-4, ".kml", 4)==0) {
+					mimeparser->kml = dc_kml_parse(mimeparser->context,
+						decoded_data, decoded_data_bytes);
+					goto cleanup;
 				}
 
 				dc_replace_bad_utf8_chars(desired_filename);

--- a/src/dc_mimeparser.h
+++ b/src/dc_mimeparser.h
@@ -64,6 +64,7 @@ struct _dc_mimeparser
 
 	int                    is_system_message;
 
+	struct _dc_kml*        kml;
 };
 
 

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -1577,6 +1577,23 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 
 		}
 
+		if (mime_parser->kml && chat_id > DC_CHAT_ID_LAST_SPECIAL)
+		{
+			/******************************************************************
+			 * save locations
+			 *****************************************************************/
+
+			dc_contact_t* contact = dc_get_contact(context, from_id);
+			if (mime_parser->kml->addr
+			 && strcasecmp(contact->addr, mime_parser->kml->addr)==0)
+			{
+				if (dc_save_locations(context, chat_id, from_id, mime_parser->kml->locations)) {
+					context->cb(context, DC_EVENT_LOCATION_CHANGED, from_id, 0);
+				}
+			}
+			dc_contact_unref(contact);
+		}
+
 		if (add_delete_job && carray_count(created_db_entries)>=2) {
 			dc_job_add(context, DC_JOB_DELETE_MSG_ON_IMAP, (int)(uintptr_t)carray_get(created_db_entries, 1), NULL, 0);
 		}

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -566,7 +566,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			}
 		#undef NEW_DB_VERSION
 
-		#define NEW_DB_VERSION 51
+		#define NEW_DB_VERSION 52
 			if (dbversion < NEW_DB_VERSION)
 			{
 				// the messages containing _only_ locations
@@ -582,6 +582,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 							" msg_id INTEGER DEFAULT 0);");
 				dc_sqlite3_execute(sql, "CREATE INDEX locations_index1 ON locations (from_id);");
 				dc_sqlite3_execute(sql, "CREATE INDEX locations_index2 ON locations (timestamp);");
+				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_send_begin INTEGER DEFAULT 0;");
 				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_send_until INTEGER DEFAULT 0;");
 				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_last_sent INTEGER DEFAULT 0;");
 				dc_sqlite3_execute(sql, "CREATE INDEX chats_index3 ON chats (locations_send_until);");

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -580,7 +580,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 							" chat_id INTEGER DEFAULT 0,"
 							" from_id INTEGER DEFAULT 0,"
 							" msg_id INTEGER DEFAULT 0);");
-				dc_sqlite3_execute(sql, "CREATE INDEX locations_index1 ON locations (msg_id);");
+				dc_sqlite3_execute(sql, "CREATE INDEX locations_index1 ON locations (from_id);");
 				dc_sqlite3_execute(sql, "CREATE INDEX locations_index2 ON locations (timestamp);");
 				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_send_until INTEGER DEFAULT 0;");
 				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_last_sent INTEGER DEFAULT 0;");

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -584,6 +584,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 				dc_sqlite3_execute(sql, "CREATE INDEX locations_index2 ON locations (timestamp);");
 				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_send_until INTEGER DEFAULT 0;");
 				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_last_sent INTEGER DEFAULT 0;");
+				dc_sqlite3_execute(sql, "CREATE INDEX chats_index3 ON chats (locations_send_until);");
 
 				dbversion = NEW_DB_VERSION;
 				dc_sqlite3_set_config_int(sql, "dbversion", NEW_DB_VERSION);

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -566,6 +566,30 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			}
 		#undef NEW_DB_VERSION
 
+		#define NEW_DB_VERSION 51
+			if (dbversion < NEW_DB_VERSION)
+			{
+				// the messages containing _only_ locations
+				// are also added to the database as _hidden_.
+				dc_sqlite3_execute(sql, "CREATE TABLE locations ("
+							" id INTEGER PRIMARY KEY,"
+							" latitude REAL DEFAULT 0.0,"
+							" longitude REAL DEFAULT 0.0,"
+							" accuracy REAL DEFAULT 0.0,"
+							" timestamp INTEGER DEFAULT 0,"
+							" chat_id INTEGER DEFAULT 0,"
+							" from_id INTEGER DEFAULT 0,"
+							" msg_id INTEGER DEFAULT 0);");
+				dc_sqlite3_execute(sql, "CREATE INDEX locations_index1 ON locations (msg_id);");
+				dc_sqlite3_execute(sql, "CREATE INDEX locations_index2 ON locations (timestamp);");
+				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_send_until INTEGER DEFAULT 0;");
+				dc_sqlite3_execute(sql, "ALTER TABLE chats ADD COLUMN locations_last_sent INTEGER DEFAULT 0;");
+
+				dbversion = NEW_DB_VERSION;
+				dc_sqlite3_set_config_int(sql, "dbversion", NEW_DB_VERSION);
+			}
+		#undef NEW_DB_VERSION
+
 		// (2) updates that require high-level objects
 		// (the structure is complete now and all objects are usable)
 		// --------------------------------------------------------------------

--- a/src/dc_stock.c
+++ b/src/dc_stock.c
@@ -29,6 +29,8 @@ static char* default_string(int id)
 		case DC_STR_MSGADDMEMBER:          return dc_strdup("Member %1$s added.");
 		case DC_STR_MSGDELMEMBER:          return dc_strdup("Member %1$s removed.");
 		case DC_STR_MSGGROUPLEFT:          return dc_strdup("Group left.");
+		case DC_STR_MSGLOCATIONENABLED:    return dc_strdup("Location streaming enabled.");
+		case DC_STR_MSGLOCATIONDISABLED:   return dc_strdup("Location streaming disabled.");
 		case DC_STR_MSGACTIONBYUSER:       return dc_strdup("%1$s by %2$s.");
 		case DC_STR_MSGACTIONBYME:         return dc_strdup("%1$s by me.");
 		case DC_STR_E2E_AVAILABLE:         return dc_strdup("End-to-end encryption available.");

--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -677,7 +677,7 @@ static int tmcomp(struct tm * atmp, struct tm * btmp) /* from mailcore2 */
 }
 
 
-static time_t mkgmtime(struct tm * tmp) /* from mailcore2 */
+time_t mkgmtime(struct tm * tmp) /* from mailcore2 */
 {
     int       dir = 0;
     int       bits = 0;
@@ -730,6 +730,7 @@ time_t dc_timestamp_from_date(struct mailimf_date_time * date_time) /* from mail
     int       zone_min = 0;
     int       zone_hour = 0;
 
+    memset(&tmval, 0, sizeof(struct tm));
     tmval.tm_sec  = date_time->dt_sec;
     tmval.tm_min  = date_time->dt_min;
     tmval.tm_hour = date_time->dt_hour;

--- a/src/dc_tools.h
+++ b/src/dc_tools.h
@@ -62,6 +62,7 @@ time_t                     dc_timestamp_from_date             (struct mailimf_da
 char*                      dc_timestamp_to_str                (time_t); /* the return value must be free()'d */
 struct mailimap_date_time* dc_timestamp_to_mailimap_date_time (time_t);
 long                       dc_gm2local_offset                 (void);
+time_t                     mkgmtime                           (struct tm*);
 
 /* timesmearing */
 time_t dc_smeared_time               (dc_context_t*);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -365,6 +365,7 @@ void        dc_send_locations_to_chat       (dc_context_t*, uint32_t chat_id, in
 int         dc_is_sending_locations_to_chat (dc_context_t*, uint32_t chat_id);
 int         dc_set_location                 (dc_context_t*, double latitude, double longitude, double accuracy);
 dc_array_t* dc_get_locations                (dc_context_t*, uint32_t chat_id, uint32_t  contact_id);
+void        dc_delete_all_locations         (dc_context_t*);
 
 
 /**
@@ -1000,6 +1001,8 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  * Location of one or more contact has changed.
  *
  * @param data1 (int) contact_id of the contact for which the location has changed.
+ *     If the locations of several contacts have been changed,
+ *     eg. after calling dc_delete_all_locations(), this parameter is set to 0.
  * @param data2 0
  * @return 0
  */

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -361,9 +361,11 @@ uint32_t        dc_join_securejoin           (dc_context_t*, const char* qr);
 
 
 // location streaming
-void dc_send_locations_to_chat       (dc_context_t*, uint32_t chat_id, int seconds);
-int  dc_is_sending_locations_to_chat (dc_context_t*, uint32_t chat_id);
-int  dc_set_location                 (dc_context_t*, double latitude, double longitude, double accuracy);
+void        dc_send_locations_to_chat       (dc_context_t*, uint32_t chat_id, int seconds);
+int         dc_is_sending_locations_to_chat (dc_context_t*, uint32_t chat_id);
+int         dc_set_location                 (dc_context_t*, double latitude, double longitude, double accuracy);
+dc_array_t* dc_get_locations                (dc_context_t*, uint32_t chat_id, uint32_t  contact_id);
+
 
 /**
  * @class dc_array_t
@@ -373,8 +375,6 @@ int  dc_set_location                 (dc_context_t*, double latitude, double lon
  * The items of the array are typically IDs.
  * To free an array object, use dc_array_unref().
  */
-dc_array_t*      dc_array_new                (dc_context_t*, size_t initsize);
-void             dc_array_empty              (dc_array_t*);
 void             dc_array_unref              (dc_array_t*);
 
 void             dc_array_add_uint           (dc_array_t*, uintptr_t);
@@ -385,6 +385,11 @@ size_t           dc_array_get_cnt            (const dc_array_t*);
 uintptr_t        dc_array_get_uint           (const dc_array_t*, size_t index);
 uint32_t         dc_array_get_id             (const dc_array_t*, size_t index);
 void*            dc_array_get_ptr            (const dc_array_t*, size_t index);
+double           dc_array_get_latitude       (const dc_array_t*, size_t index);
+double           dc_array_get_longitude      (const dc_array_t*, size_t index);
+double           dc_array_get_accuracy       (const dc_array_t*, size_t index);
+time_t           dc_array_get_timestamp      (const dc_array_t*, size_t index);
+uint32_t         dc_array_get_msg_id         (const dc_array_t*, size_t index);
 
 int              dc_array_search_id          (const dc_array_t*, uint32_t needle, size_t* indx);
 const uintptr_t* dc_array_get_raw            (const dc_array_t*);

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -1205,7 +1205,9 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
 #define DC_STR_SERVER_RESPONSE            61
 #define DC_STR_MSGACTIONBYUSER            62
 #define DC_STR_MSGACTIONBYME              63
-#define DC_STR_COUNT                      64
+#define DC_STR_MSGLOCATIONENABLED         64
+#define DC_STR_MSGLOCATIONDISABLED        65
+#define DC_STR_COUNT                      65
 
 /*
  * @}

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -360,6 +360,11 @@ char*           dc_get_securejoin_qr         (dc_context_t*, uint32_t chat_id);
 uint32_t        dc_join_securejoin           (dc_context_t*, const char* qr);
 
 
+// location streaming
+void dc_send_locations_to_chat       (dc_context_t*, uint32_t chat_id, int seconds);
+int  dc_is_sending_locations_to_chat (dc_context_t*, uint32_t chat_id);
+int  dc_set_location                 (dc_context_t*, double latitude, double longitude, double accuracy);
+
 /**
  * @class dc_array_t
  *
@@ -983,6 +988,17 @@ time_t          dc_lot_get_timestamp     (const dc_lot_t*);
  * @return 0
  */
 #define DC_EVENT_CONTACTS_CHANGED         2030
+
+
+
+/**
+ * Location of one or more contact has changed.
+ *
+ * @param data1 (int) contact_id of the contact for which the location has changed.
+ * @param data2 0
+ * @return 0
+ */
+#define DC_EVENT_LOCATION_CHANGED         2035
 
 
 /**

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ lib_src = [
   'dc_loginparam.c',
   'dc_lot.c',
   'dc_move.c',
+  'dc_location.c',
   'dc_context.c',
   'dc_configure.c',
   'dc_e2ee.c',


### PR DESCRIPTION
this pr aims to provide basic functions to allow the streaming of locations.

- [X] enable/disable location streaming for a chat
- [X] add a function to send the current location
- [X] send location with outgoing messages, ~~just in a Chat-Location header for now~~ in a `.kml`-file
- [X] add interface to get locations for rendering a map
- [x] read location from incoming message headers
- [x] add a function to delete all locations
- [x] make sure, no location older than the time where dc_send_locations_to_chat() was called are sent out
- [x] set timestamp of last-kml-sending
- [x] add multiple locations to kml-file
- [x] send location-only messages from time to time (if there are no normal messages to send)