### PR TITLE
Update README.md, suggest using `sudo -E`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ meson
 # run `meson configure` to see the options, e.g.
 #    meson configure --default-library=static
 ninja
-sudo ninja install
+sudo -E ninja install
 sudo ldconfig
 ```
 


### PR DESCRIPTION
`sudo -E ninja install`

The -E parameter is necessary to get this commad working as expected.
Reason is because meson is installed for current user (pip) with given instructions and if we use sudo command python3 is not able to find installed package. sudo sees another environment as current user.
The -E command passed current environment to sudo user.