### PR TITLE
show up autocrypt setup messages even if emails are not displayed

### DIFF
--- a/src/dc_mimeparser.c
+++ b/src/dc_mimeparser.c
@@ -1533,7 +1533,6 @@ void dc_mimeparser_parse(dc_mimeparser_t* mimeparser, const char* body_not_termi
 				}
 			}
 		}
-		mimeparser->is_send_by_messenger = 0; /* do not treat a setup message as a messenger message (eg. do not move setup messages to the Chats-folder; there may be a 3rd device that wants to handle it) */
 	}
 
 	/* some special system message? */

--- a/src/dc_move.c
+++ b/src/dc_move.c
@@ -19,6 +19,12 @@ void dc_do_heuristics_moves(dc_context_t* context, const char* folder, uint32_t 
 
 	msg = dc_msg_new_load(context, msg_id);
 
+	if (dc_msg_is_setupmessage(msg)) {
+		// do not move setup messages;
+		// there may be a non-delta device that wants to handle it
+		goto cleanup;
+	}
+
 	if (dc_is_mvbox(context, folder)) {
 		dc_update_msg_move_state(context, msg->rfc724_mid, DC_MOVE_STATE_STAY);
 		goto cleanup;


### PR DESCRIPTION
with https://github.com/deltachat/deltachat-core/pull/588 (email-interations), emails are not shown by default.

however, autocrypt-setup-messages should always show up.

this pr fixes this issue.
(there was no official release where the asm did not work)