### PR TITLE
adapt key size

### DIFF
--- a/src/dc_pgp.h
+++ b/src/dc_pgp.h
@@ -21,7 +21,7 @@ void dc_pgp_rand_seed        (dc_context_t*, const void* buf, size_t bytes);
 int  dc_split_armored_data  (char* buf, const char** ret_headerline, const char** ret_setupcodebegin, const char** ret_preferencrypt, const char** ret_base64);
 
 /* public key encryption */
-#define DC_KEYGEN_BITS  3072
+#define DC_KEYGEN_BITS  2048
 #define DC_KEYGEN_E    65537
 int  dc_pgp_create_keypair   (dc_context_t*, const char* addr, dc_key_t* public_key, dc_key_t* private_key);
 


### PR DESCRIPTION
this pr changes the default key size to 2048 bit

the previously used 3072 bit only [add only few entropy](https://www.gnupg.org/faq/gnupg-faq.html#no_default_of_rsa4096) (128 bit vs. 112 bit) and have huge drawbacks as slow generation, operations and larger sizes. also the 112 bit fit good to the entropy used for the [setup code](https://autocrypt.org/level1.html#setup-code) 

the mid-term plan, however is to go for ecc keys.

users can still import keys of other sizes as they like.