### PR TITLE
handle delete wrt early-mime-generation

### DIFF
--- a/src/dc_msg.h
+++ b/src/dc_msg.h
@@ -96,6 +96,7 @@ The value is also used for CC:-summaries */
 
 
 // Context functions to work with messages
+int             dc_msg_exists                              (dc_context_t*, uint32_t msg_id);
 void            dc_update_msg_chat_id                      (dc_context_t*, uint32_t msg_id, uint32_t chat_id);
 void            dc_update_msg_state                        (dc_context_t*, uint32_t msg_id, int state);
 void            dc_update_msg_move_state                   (dc_context_t*, const char* rfc724_mid, dc_move_state_t);

--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -228,7 +228,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			dc_sqlite3_execute(sql, "CREATE TABLE config (id INTEGER PRIMARY KEY, keyname TEXT, value TEXT);");
 			dc_sqlite3_execute(sql, "CREATE INDEX config_index1 ON config (keyname);");
 
-			dc_sqlite3_execute(sql, "CREATE TABLE contacts (id INTEGER PRIMARY KEY,"
+			dc_sqlite3_execute(sql, "CREATE TABLE contacts (id INTEGER PRIMARY KEY AUTOINCREMENT,"
 						" name TEXT DEFAULT '',"
 						" addr TEXT DEFAULT '' COLLATE NOCASE,"
 						" origin INTEGER DEFAULT 0,"
@@ -242,7 +242,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 				#error
 			#endif
 
-			dc_sqlite3_execute(sql, "CREATE TABLE chats (id INTEGER PRIMARY KEY, "
+			dc_sqlite3_execute(sql, "CREATE TABLE chats (id INTEGER PRIMARY KEY AUTOINCREMENT, "
 						" type INTEGER DEFAULT 0,"
 						" name TEXT DEFAULT '',"
 						" draft_timestamp INTEGER DEFAULT 0,"
@@ -261,7 +261,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 				#error
 			#endif
 
-			dc_sqlite3_execute(sql, "CREATE TABLE msgs (id INTEGER PRIMARY KEY,"
+			dc_sqlite3_execute(sql, "CREATE TABLE msgs (id INTEGER PRIMARY KEY AUTOINCREMENT,"
 						" rfc724_mid TEXT DEFAULT '',"     /* forever-global-unique Message-ID-string, unfortunately, this cannot be easily used to communicate via IMAP */
 						" server_folder TEXT DEFAULT '',"  /* folder as used on the server, the folder will change when messages are moved around. */
 						" server_uid INTEGER DEFAULT 0,"   /* UID as used on the server, the UID will change when messages are moved around, unique together with validity, see RFC 3501; the validity may differ from folder to folder.  We use the server_uid for "markseen" and to delete messages as we check against the message-id, we ignore the validity for these commands. */


### PR DESCRIPTION
this pr does not sent generated mime-structure out if the corresponding database entry does not or no longer exist on sending time. 

this is typically the case if one sends a message without having network and deletes the message before the network comes back again.
due to the early-mime-generation, we _could_ send out the message in this case, however, usually, this is not desired.

finally, this pr also adds the [AUTOINCREMENT](https://sqlite.org/autoinc.html) keyword, to avoid problems eg. if the last message was delete before sending but _another_ messages get the same msg_id later on. as this flag is not easily changeable for existing databases, we add it only for new ones. in practice, however, messages are not directly deleted but marked with a special flag and are physically delete from db if there is network again, so, the problem is very unlikely even for existing databases.

@VP- would be great if you can have a look; maybe i've missed something :) - and feel free to merge :)