### PR TITLE
Emit DC_EVENT_MSGS_CHANGED from dc_prepare_msg()

### DIFF
--- a/python/tests/test_increation.py
+++ b/python/tests/test_increation.py
@@ -25,6 +25,7 @@ class TestInCreation:
         open(path, 'a').close()
         prepared_original = chat.prepare_file(path)
         assert prepared_original.get_state().is_out_preparing()
+        wait_msgs_changed(ac1, chat.id, prepared_original.id)
 
         lp.sec("forward the message while still in creation")
         chat2 = ac1.create_group_chat("newgroup")

--- a/src/dc_chat.c
+++ b/src/dc_chat.c
@@ -2533,7 +2533,11 @@ uint32_t dc_prepare_msg(dc_context_t* context, uint32_t chat_id, dc_msg_t* msg)
 	}
 
 	msg->state = DC_STATE_OUT_PREPARING;
-	return prepare_msg_common(context, chat_id, msg);
+	uint32_t msg_id = prepare_msg_common(context, chat_id, msg);
+
+	context->cb(context, DC_EVENT_MSGS_CHANGED, msg->chat_id, msg->id);
+
+	return msg_id;
 }
 
 /**


### PR DESCRIPTION
To allow UIs to rely entirely on events do display messages, `dc_prepare_msg()` should emit events just like `dc_send_msg()`. Calling `dc_send_msg()` directly will emit the event only once, since the PREPARING state is skipped entirely.