### PR TITLE
call setlocale() to force point as decimal separator for floats

### DIFF
--- a/cmdline/stress.c
+++ b/cmdline/stress.c
@@ -370,6 +370,13 @@ void stress_functions(dc_context_t* context)
 		assert( atol("")==0 ); /* we rely on this eg. in dc_sqlite3_get_config() */
 		assert( atoi("")==0 );
 
+		double f = atof("1.23");
+		assert( f>1.22 && f<1.24 );
+
+		char* s = dc_mprintf("%0.2f", 1.23);
+		assert( strcmp(s, "1.23")==0 );
+		free(s);
+
 		assert( !dc_may_be_valid_addr(NULL) );
 		assert( !dc_may_be_valid_addr("") );
 		assert(  dc_may_be_valid_addr("user@domain.tld") );

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -1,5 +1,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <locale.h>
 #include <unistd.h>
 #include <openssl/opensslv.h>
 #include <assert.h>
@@ -180,6 +181,15 @@ static void cb_receive_imf(dc_imap_t* imap, const char* imf_raw_not_terminated, 
 dc_context_t* dc_context_new(dc_callback_t cb, void* userdata, const char* os_name)
 {
 	dc_context_t* context = NULL;
+
+	// set locale to make printf("%d") and atof() work with a point-decimal-separator.
+	// as setlocale() may not be thread-safe and one call is sufficient for all
+	//
+	static int s_locale_initialized = 0;
+	if (!s_locale_initialized) {
+		s_locale_initialized = 1;
+		setlocale(LC_ALL|~LC_NUMERIC, "C");
+	}
 
 	if ((context=calloc(1, sizeof(dc_context_t)))==NULL) {
 		exit(23); /* cannot allocate little memory, unrecoverable error */


### PR DESCRIPTION
this should make atof() and printf("%f") work as expected, needed eg. to parse latitude and longitude from kml files