### PR TITLE
add some more colors

### DIFF
--- a/src/dc_tools.c
+++ b/src/dc_tools.c
@@ -608,15 +608,17 @@ int dc_str_to_color(const char* str)
 {
 	char* str_lower = dc_strlower(str);
 
+	/* the colors must fulfill some criterions as:
+	- contrast to black and to white
+	- work as a text-color
+	- being noticable on a typical map
+	- harmonize together while being different enough
+	(therefore, we cannot just use random rgb colors :) */
 	static uint32_t colors[] = {
-		0xe56555,
-		0xf28c48,
-		0x8e85ee,
-		0x76c84d,
-		0x5bb6cc,
-		0x549cdd,
-		0xd25c99,
-		0xb37800
+		0xe56555, 0xf28c48, 0x8e85ee, 0x76c84d,
+		0x5bb6cc, 0x549cdd, 0xd25c99, 0xb37800,
+		0xf23030, 0x39B249, 0xBB243B, 0x964078,
+		0x66874F, 0x308AB9, 0x127ed0, 0xBE450C
 	};
 
 	int checksum = 0;


### PR DESCRIPTION
this pr doubles the number of available colors for contacs and groups (if no image is set) and decreases the probability of a collisions (as the color is never the only hint, collisions as such are okay).

the colors must fulfill some criterions as: contrast to black and to white, work as a text-color, being noticable on a map and harmonize together while being differnt enough - therefore, we cannot just use random rgb colors :)

new palette:

![Screenshot from 2019-03-27 00-21-04](https://user-images.githubusercontent.com/9800740/55039866-4352f400-5026-11e9-9771-ea9e6ddbceb4.png)