### PR TITLE
quick-check if location-streaming is enabled for any chat

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -727,6 +727,9 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 					dc_log_info(context, 0, "================================================================================");
 				}
 			}
+			if (dc_is_sending_locations_to_chat(context, 0)) {
+				dc_log_info(context, 0, "Location streaming enabled.");
+			}
 			ret = dc_mprintf("%i chats.", (int)cnt);
 			dc_chatlist_unref(chatlist);
 		}


### PR DESCRIPTION
this pr modifies dc_is_sending_locations_to_chat() so that it can be used to check if location-streaming is enabled for _any_ chat.

this is useful esp. on program startup where the app may want to initialize the location-engine only if needed.