### PR TITLE
do not notify hidden location messages

### DIFF
--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -932,6 +932,7 @@ dc_array_t* dc_get_fresh_msgs(dc_context_t* context)
 		" LEFT JOIN contacts ct ON m.from_id=ct.id"
 		" LEFT JOIN chats c ON m.chat_id=c.id"
 		" WHERE m.state=?"
+		"   AND m.hidden=0"
 		"   AND m.chat_id>?"
 		"   AND ct.blocked=0"
 		"   AND (c.blocked=0 OR c.blocked=?)"

--- a/src/dc_receive_imf.c
+++ b/src/dc_receive_imf.c
@@ -1411,6 +1411,9 @@ void dc_receive_imf(dc_context_t* context, const char* imf_raw_not_terminated, s
 				if (mime_parser->kml && icnt==1 && part->msg
 				 && (strcmp(part->msg, "-location-")==0 || part->msg[0]==0)) {
 					hidden = 1;
+					if (state==DC_STATE_IN_FRESH) {
+						state = DC_STATE_IN_NOTICED;
+					}
 				}
 
 				if (part->type==DC_MSG_TEXT) {


### PR DESCRIPTION
they were not really notified as the state is checked again later, however, hidden messages should not even being returned from dc_get_fresh_msgs()