### PR TITLE
autoincrement id in jobs-table

### DIFF
--- a/src/dc_sqlite3.c
+++ b/src/dc_sqlite3.c
@@ -307,7 +307,7 @@ int dc_sqlite3_open(dc_sqlite3_t* sql, const char* dbfile, int flags)
 			dc_sqlite3_execute(sql, "CREATE INDEX msgs_index4 ON msgs (state);");          /* for selecting the count of fresh messages (as there are normally only few unread messages, an index over the chat_id is not required for _this_ purpose */
 			dc_sqlite3_execute(sql, "INSERT INTO msgs (id,msgrmsg,txt) VALUES (1,0,'marker1'), (2,0,'rsvd'), (3,0,'rsvd'), (4,0,'rsvd'), (5,0,'rsvd'), (6,0,'rsvd'), (7,0,'rsvd'), (8,0,'rsvd'), (9,0,'daymarker');"); /* make sure, the reserved IDs are not used */
 
-			dc_sqlite3_execute(sql, "CREATE TABLE jobs (id INTEGER PRIMARY KEY,"
+			dc_sqlite3_execute(sql, "CREATE TABLE jobs (id INTEGER PRIMARY KEY AUTOINCREMENT,"
 						" added_timestamp INTEGER,"
 						" desired_timestamp INTEGER DEFAULT 0,"
 						" action INTEGER,"


### PR DESCRIPTION
this pr modifies the id-column in the jobs table so that no id is used twice. 

the standard sqlite behavior is to reuse ids. so it might happen that a newly added job gets the same id as a job that was executed and already removed from the database.

this may be a problem if we decide to use the job-ids from external, eg. to check if a given job was executed.

tackles the raw-receiving of mime-messages.