### PR TITLE
Make intention clear, rather than work by accident

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -403,7 +403,7 @@ class EventLogger:
 
     def _log_event(self, evt_name, data1, data2):
         # don't show events that are anyway empty impls now
-        if evt_name in ("DC_EVENT_GET_STRING"):
+        if evt_name == "DC_EVENT_GET_STRING":
             return
         if self._debug:
             evpart = "{}({!r},{!r})".format(evt_name, data1, data2)


### PR DESCRIPTION
In the current version this was a tuple containing two elements. Now it is just a string wrapped in parentheses => simplify to check by direct comparison.