### PR TITLE
[wip] dc_get_locations() can return message-only-locations or full-track

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -911,7 +911,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 	else if(strcmp(cmd, "getlocations")==0)
 	{
 		int contact_id = arg1? atoi(arg1) : 0;
-		dc_array_t* loc = dc_get_locations(context, dc_chat_get_id(sel_chat), contact_id, 0, 0);
+		dc_array_t* loc = dc_get_locations(context, dc_chat_get_id(sel_chat), contact_id, 0, 0, DC_GL_TRACK);
 		for (int j=0; j<dc_array_get_cnt(loc); j++) {
 			char* timestr = dc_timestamp_to_str(dc_array_get_timestamp(loc, j));
 			char* marker = dc_array_get_marker(loc, j);

--- a/src/dc_location.c
+++ b/src/dc_location.c
@@ -697,6 +697,10 @@ static int is_marker(const char* txt)
  * @param timestamp_to End of timespan to return.
  *     Must be given in number of seconds since 00:00 hours, Jan 1, 1970 UTC.
  *     0 for "all up to now".
+ * @param flags can be a combination of
+ *     DC_GL_MESSAGES (return all positions with messages) or
+ *     DC_GL_TRACK (return all positions, typically to draw a track)
+ *     If no flag is given, the last known position in the timespan is returned.
  * @return Array of locations, NULL is never returned.
  *     The array is sorted decending;
  *     the first entry in the array is the location with the newest timestamp.
@@ -728,7 +732,8 @@ static int is_marker(const char* txt)
  */
 dc_array_t* dc_get_locations(dc_context_t* context,
                              uint32_t chat_id, uint32_t  contact_id,
-                             time_t timestamp_from, time_t timestamp_to)
+                             time_t timestamp_from, time_t timestamp_to,
+                             int flags)
 {
 	dc_array_t*   ret = dc_array_new_typed(context, DC_ARRAY_LOCATIONS, 500);
 	sqlite3_stmt* stmt = NULL;

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -364,7 +364,12 @@ uint32_t        dc_join_securejoin           (dc_context_t*, const char* qr);
 void        dc_send_locations_to_chat       (dc_context_t*, uint32_t chat_id, int seconds);
 int         dc_is_sending_locations_to_chat (dc_context_t*, uint32_t chat_id);
 int         dc_set_location                 (dc_context_t*, double latitude, double longitude, double accuracy);
-dc_array_t* dc_get_locations                (dc_context_t*, uint32_t chat_id, uint32_t contact_id, time_t timestamp_begin, time_t timestamp_end);
+
+#define     DC_GL_MESSAGES                  0x01
+#define     DC_GL_TRACK                     0x02
+dc_array_t* dc_get_locations                (dc_context_t*, uint32_t chat_id, uint32_t contact_id,
+                                             time_t timestamp_begin, time_t timestamp_end, int flags);
+
 void        dc_delete_all_locations         (dc_context_t*);
 
 


### PR DESCRIPTION
this pr aims to modify dc_get_locations() so that it takes a flag parameter. for now, i've only prototyped the flags as follows:

- if DC_GL_MESSAGES is set, dc_get_locations() returns all locations selected by chat/contact/timespan that contain messages
- if DC_GL_TRACKS is set, dc_get_locations() returns all known locations selected by chat/contact/timespan; this can be used to draw a track then. this includes the locations returned by DC_GL_MESSAGES

the last location selected by chat/contact/timespan is always added implicitly. if only this information is wanted, the flags parameter can be set to 0.

@cyBerta @nicodh makes sense? what do you think?