### PR TITLE
Use newer sphinx

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -38,8 +38,9 @@ commands =
     rst-lint --encoding 'utf-8' README.rst
 
 [testenv:doc]
+basepython = python3.5
 deps =
-    sphinx==1.8.5
+    sphinx==2.0.1
     breathe
 
 changedir = doc


### PR DESCRIPTION
This should hopefully fix the CI again.  The version pinning might
be overly strict, not sure how versions work in tox though.