### PR TITLE
Hardcode version in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,36 +1,14 @@
 project(
   'deltachat-core', 'c',
   license: 'GPLv3',
-  version: '0.0.0',             # Dummy, see below.
+  version: '0.43.0',
   subproject_dir: 'libs',
   meson_version: '>=0.47.2',
   default_options: ['c_std=gnu99'],
 )
 
 
-## Figure out the version, use this instead of meson.project_version()
-# The version schema is:
-#  - X.Y.Z for tagged releases.
-#  - X.Y.Z990N for dev releases.
-#    Where N is the number of commits since the last tag.
 version = meson.project_version()
-git = find_program('git', required: false)
-if git.found()
-  git_desc = run_command(git, 'describe', '--tags', '--match=v*')
-  if git_desc.returncode() == 0
-    git_desc_parts = git_desc.stdout().strip().split('-')
-    version = git_desc_parts[0].split('v')[1]
-    if git_desc_parts.length() > 1
-      version_parts = version.split('.')
-      version = '.'.join([version_parts[0],
-                          version_parts[1],
-                          version_parts[2] + '990' + git_desc_parts[1]])
-    endif
-  endif
-endif
-if version == meson.project_version()
-  warning('Git version not found, using (dummy) project version')
-endif
 
 
 # pthreads is not a real dependency


### PR DESCRIPTION
The current way of using some git magic to determine the dcc version fails because it's not run in the correct folder. This blocks us from using the current core in -desktop. As meson will go away soon anyway, i just hardcoded the current version. Hotfix.