### PR TITLE
empty server folder

### DIFF
--- a/cmdline/cmdline.c
+++ b/cmdline/cmdline.c
@@ -477,6 +477,7 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 				"checkqr <qr-content>\n"
 				"event <event-id to test>\n"
 				"fileinfo <file>\n"
+				"emptyserver [mvbox|inbox]\n"
 				"clear -- clear screen\n" /* must be implemented by  the caller */
 				"exit\n" /* must be implemented by  the caller */
 				"============================================="
@@ -1343,6 +1344,21 @@ char* dc_cmdline(dc_context_t* context, const char* cmdline)
 		}
 		else {
 			ret = dc_strdup("ERROR: Argument <file> missing.");
+		}
+	}
+	else if (strcmp(cmd, "emptyserver")==0)
+	{
+		int flags = 0;
+		if (arg1) {
+			if (strstr(arg1, "mvbox")!=NULL) { flags|= DC_EMPTY_MVBOX; }
+			if (strstr(arg1, "inbox")!=NULL) { flags|= DC_EMPTY_INBOX; }
+		}
+		if (flags) {
+			dc_empty_server(context, flags);
+			ret = COMMAND_SUCCEEDED;
+		}
+		else {
+			ret = dc_strdup("ERROR: Argument [mvbox|inbox] missing.");
 		}
 	}
 	else

--- a/src/dc_context.c
+++ b/src/dc_context.c
@@ -205,6 +205,8 @@ dc_context_t* dc_context_new(dc_callback_t cb, void* userdata, const char* os_na
 
 	dc_pgp_init();
 	context->sql      = dc_sqlite3_new(context);
+	dc_job_kill_action(context, DC_JOB_EMPTY_SERVER);
+
 	context->inbox    = dc_imap_new(cb_get_config, cb_set_config, cb_precheck_imf, cb_receive_imf, (void*)context, context);
 	context->sentbox_thread.imap = dc_imap_new(cb_get_config, cb_set_config, cb_precheck_imf, cb_receive_imf, (void*)context, context);
 	context->mvbox_thread.imap = dc_imap_new(cb_get_config, cb_set_config, cb_precheck_imf, cb_receive_imf, (void*)context, context);

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -1343,6 +1343,19 @@ cleanup:
 }
 
 
-void dc_imap_empty_folders(dc_imap_t* imap, int flags)
+void dc_imap_empty_folder(dc_imap_t* imap, const char* folder)
 {
+	if (imap==NULL || folder==NULL || folder[0]==0) {
+		goto cleanup;
+	}
+
+	dc_log_info(imap->context, 0, "Emptying folder \"%s\" ...", folder);
+
+	if (select_folder(imap, folder)==0) {
+		dc_log_warning(imap->context, 0, "Cannot select folder %s for emptying.", folder);
+		goto cleanup;
+	}
+
+cleanup:
+	;
 }

--- a/src/dc_imap.c
+++ b/src/dc_imap.c
@@ -1342,3 +1342,7 @@ cleanup:
 
 }
 
+
+void dc_imap_empty_folders(dc_imap_t* imap, int flags)
+{
+}

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -103,7 +103,7 @@ dc_imap_res dc_imap_set_seen     (dc_imap_t*, const char* folder, uint32_t uid);
 dc_imap_res dc_imap_set_mdnsent  (dc_imap_t*, const char* folder, uint32_t uid);
 
 int        dc_imap_delete_msg        (dc_imap_t*, const char* rfc724_mid, const char* folder, uint32_t server_uid); /* only returns 0 on connection problems; we should try later again in this case */
-void       dc_imap_empty_folders     (dc_imap_t*, int flags);
+void       dc_imap_empty_folder      (dc_imap_t*, const char* folder);
 
 int        dc_imap_is_error          (dc_imap_t* imap, int code);
 

--- a/src/dc_imap.h
+++ b/src/dc_imap.h
@@ -103,6 +103,7 @@ dc_imap_res dc_imap_set_seen     (dc_imap_t*, const char* folder, uint32_t uid);
 dc_imap_res dc_imap_set_mdnsent  (dc_imap_t*, const char* folder, uint32_t uid);
 
 int        dc_imap_delete_msg        (dc_imap_t*, const char* rfc724_mid, const char* folder, uint32_t server_uid); /* only returns 0 on connection problems; we should try later again in this case */
+void       dc_imap_empty_folders     (dc_imap_t*, int flags);
 
 int        dc_imap_is_error          (dc_imap_t* imap, int code);
 

--- a/src/dc_job.c
+++ b/src/dc_job.c
@@ -79,6 +79,8 @@ cleanup:
 
 static void dc_job_do_DC_JOB_EMPTY_SERVER(dc_context_t* context, dc_job_t* job)
 {
+	char* mvbox_name = NULL;
+
 	if (!dc_imap_is_connected(context->inbox)) {
 		connect_to_inbox(context);
 		if (!dc_imap_is_connected(context->inbox)) {
@@ -86,10 +88,19 @@ static void dc_job_do_DC_JOB_EMPTY_SERVER(dc_context_t* context, dc_job_t* job)
 		}
 	}
 
-	dc_imap_empty_folders(context->inbox, job->foreign_id);
+	if (job->foreign_id&DC_EMPTY_MVBOX) {
+		char* mvbox_name = dc_sqlite3_get_config(context->sql, "configured_mvbox_folder", NULL);
+		if (mvbox_name && mvbox_name[0]) {
+			dc_imap_empty_folder(context->inbox, mvbox_name);
+		}
+	}
+
+	if (job->foreign_id&DC_EMPTY_INBOX) {
+		dc_imap_empty_folder(context->inbox, "INBOX");
+	}
 
 cleanup:
-	;
+	free(mvbox_name);
 }
 
 

--- a/src/dc_job.h
+++ b/src/dc_job.h
@@ -12,6 +12,7 @@ extern "C" {
 
 // jobs in the INBOX-thread, range from DC_IMAP_THREAD..DC_IMAP_THREAD+999
 #define DC_JOB_HOUSEKEEPING           105    // low priority ...
+#define DC_JOB_EMPTY_SERVER           107
 #define DC_JOB_DELETE_MSG_ON_IMAP     110
 #define DC_JOB_MARKSEEN_MDN_ON_IMAP   120
 #define DC_JOB_MARKSEEN_MSG_ON_IMAP   130

--- a/src/deltachat.h
+++ b/src/deltachat.h
@@ -343,6 +343,9 @@ int             dc_check_password            (dc_context_t*, const char* pw);
 char*           dc_initiate_key_transfer     (dc_context_t*);
 int             dc_continue_key_transfer     (dc_context_t*, uint32_t msg_id, const char* setup_code);
 void            dc_stop_ongoing_process      (dc_context_t*);
+#define         DC_EMPTY_MVBOX               0x01
+#define         DC_EMPTY_INBOX               0x02
+void            dc_empty_server              (dc_context_t*, int flags);
 
 
 // out-of-band verification


### PR DESCRIPTION
this pr adds a function to empty the mvbox and inbox. 

note that this is subject to changes, there is no need to port this directly to rust. the mid-goal is to have an automatic deletion that cleans up the folder every few days so that multi-device-support is possible and no user-action is required for deletion.